### PR TITLE
Remove unnecessary build

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,8 +18,5 @@ jobs:
       with:
         node-version: '14.x'
     - run: yarn install
-    - run: yarn build
-      env:
-        REACT_APP_ENV: development
     - run: yarn test
     


### PR DESCRIPTION
Building the production static assets is unnecessary for test running. 