### PR TITLE
Fix approved total number

### DIFF
--- a/src/components/EditorHeader/components/Title/Title.js
+++ b/src/components/EditorHeader/components/Title/Title.js
@@ -52,7 +52,7 @@ function Title({ history, match, onEditor }) {
     header = { title: subject }
   }
   const subjectCount = header.title === group ?
-    `(${store.transcriptions.approvedCount}/${store.transcriptions.all.size} approved)` : ''
+    `(${store.transcriptions.approvedCount}/${store.transcriptions.totalCount} approved)` : ''
   return (
     <Box align='baseline'>
       <Box direction='row' wrap>

--- a/src/components/EditorHeader/components/Title/Title.spec.js
+++ b/src/components/EditorHeader/components/Title/Title.spec.js
@@ -20,7 +20,8 @@ const editContext = {
   transcriptions: {
     approvedCount: 0,
     all: { size: 0 },
-    title: 'Subject'
+    title: 'Subject',
+    totalCount: 100
   }
 }
 
@@ -71,7 +72,7 @@ describe('Component > Title', function () {
     it('should display three subheader buttons', function () {
       const approvedCount = wrapper.find(CapitalText).last().props()
       expect(wrapper.find(Button).length).toBe(3)
-      expect(approvedCount.children).toBe('(0/0 approved)')
+      expect(approvedCount.children).toBe(`(${editContext.transcriptions.approvedCount}/${editContext.transcriptions.totalCount} approved)`)
     })
 
     it('should route to the correct subheader location', function () {

--- a/src/components/Modals/DownloadDataModal/DownloadDataModalContainer.js
+++ b/src/components/Modals/DownloadDataModal/DownloadDataModalContainer.js
@@ -18,7 +18,7 @@ export default function DownloadDataModalContainer({ entireGroup }) {
       entireGroup={entireGroup}
       onClose={onClose}
       onDownload={onDownload}
-      transcriptionCount={store.transcriptions.all.size}
+      transcriptionCount={store.transcriptions.totalCount}
     />
   )
 }

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -56,6 +56,8 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   slopeDefinitions: types.optional(types.frozen(), {}),
   slopeKeys: types.array(types.string),
   totalPages: types.optional(types.number, 1),
+  approvedCount: types.optional(types.number, 1),
+  totalCount: types.optional(types.number, 1),
   rawExtracts: types.array(types.frozen()),
   parsedExtracts: types.array(types.frozen())
 }).actions(self => {
@@ -422,6 +424,8 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
       })
       undoManager.withoutUndo(() => {
         self.totalPages = resources.meta.pagination.last || resources.meta.pagination.current
+        self.approvedCount = resources.meta.approved_count
+        self.totalCount = resources.meta.pagination.records
         self.asyncState = ASYNC_STATES.READY
       })
     } catch (error) {
@@ -602,16 +606,6 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
   get approved () {
     return !!(self.current && self.current.status === STATUS.APPROVED)
-  },
-
-  get approvedCount () {
-    let count = 0;
-    self.all.forEach(transcription => {
-      if (transcription.status === STATUS.APPROVED) {
-        count ++
-      }
-    })
-    return count;
   },
 
   get lockedByCurrentUser () {

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -85,7 +85,8 @@ const multipleTranscriptionsStub = {
         {
           data: [TranscriptionFactory.build(), TranscriptionFactory.build({ id: '2', attributes: { status: STATUS.APPROVED, subject_id: '2', text: new Map() }})],
           meta: {
-            pagination: { last: 1 }
+            pagination: { last: 1, records: 2 },
+            approved_count: 1
           }
         })
     }
@@ -137,6 +138,7 @@ describe('TranscriptionsStore', function () {
       it('should fetch transcriptions', async function () {
         expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.READY)
         expect(transcriptionsStore.all.size).toBe(2)
+        expect(transcriptionsStore.totalCount).toBe(2)
       })
 
       it('should count the number of approved', async function () {


### PR DESCRIPTION
Related to issue https://github.com/zooniverse/alice/issues/233
Changes made to tove (currently deployed in staging but not in prod yet), is to send over within `meta` field of the response body of `/transcriptions` call a new attribute called `approved_count` which calculates the number of approved transcriptions that come in from the api call out of all the records queries from the call. 

NOTE (to self) : Before deploying to production, must deploy tove changes to prod first. 

![Screen Shot 2021-10-28 at 1 41 43 PM](https://user-images.githubusercontent.com/30220346/139316222-e6ec4a54-15e8-4516-8f57-6c4532a82eff.png)
![Screen Shot 2021-10-28 at 1 41 51 PM](https://user-images.githubusercontent.com/30220346/139316241-c78687df-5353-4729-9374-52624f331295.png)
