### PR TITLE
Include newly-required --overwrite flag in az uploads

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -40,6 +40,7 @@ jobs:
             az storage blob upload \
               --account-name zooniversestatic \
               --content-cache-control 'public, max-age=60' \
+              --overwrite
               --container-name '$web' \
               --name 'alice.zooniverse.org/commit_id.txt' \
               --file ./build/commit_id.txt
@@ -47,6 +48,7 @@ jobs:
             az storage blob upload \
               --account-name zooniversestatic \
               --content-cache-control 'public, max-age=60' \
+              --overwrite
               --container-name '$web' \
               --name 'alice.zooniverse.org/index.html' \
               --file ./build/index.html
@@ -54,6 +56,7 @@ jobs:
             az storage blob upload-batch \
               --account-name zooniversestatic \
               --content-cache-control 'public, immutable, max-age=604800' \
+              --overwrite
               --destination '$web/alice.zooniverse.org' \
               --source ./build
 

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -39,6 +39,7 @@ jobs:
             az storage blob upload \
               --account-name zooniversestatic \
               --content-cache-control 'public, max-age=60' \
+              --overwrite
               --container-name '$web' \
               --name 'preview.zooniverse.org/alice/commit_id.txt' \
               --file ./build/commit_id.txt
@@ -46,6 +47,7 @@ jobs:
             az storage blob upload \
               --account-name zooniversestatic \
               --content-cache-control 'public, max-age=60' \
+              --overwrite
               --container-name '$web' \
               --name 'preview.zooniverse.org/alice/index.html' \
               --file ./build/index.html
@@ -53,6 +55,7 @@ jobs:
             az storage blob upload-batch \
               --account-name zooniversestatic \
               --content-cache-control 'public, immutable, max-age=604800' \
+              --overwrite
               --destination '$web/preview.zooniverse.org/alice' \
               --source ./build
 


### PR DESCRIPTION
MS issued a breaking change in a new version of the az client used by our CI tooling: https://docs.microsoft.com/en-us/cli/azure/release-notes-azure-cli

This PR includes the `--overwrite` flag on all `az storage blob upload-batch` commands. This change should be ported to the shared ci-cd repo and this repo migrated when this is proven to work, also.