### PR TITLE
Typo: add missing backslashes

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -40,7 +40,7 @@ jobs:
             az storage blob upload \
               --account-name zooniversestatic \
               --content-cache-control 'public, max-age=60' \
-              --overwrite
+              --overwrite \
               --container-name '$web' \
               --name 'alice.zooniverse.org/commit_id.txt' \
               --file ./build/commit_id.txt
@@ -48,7 +48,7 @@ jobs:
             az storage blob upload \
               --account-name zooniversestatic \
               --content-cache-control 'public, max-age=60' \
-              --overwrite
+              --overwrite \
               --container-name '$web' \
               --name 'alice.zooniverse.org/index.html' \
               --file ./build/index.html
@@ -56,7 +56,7 @@ jobs:
             az storage blob upload-batch \
               --account-name zooniversestatic \
               --content-cache-control 'public, immutable, max-age=604800' \
-              --overwrite
+              --overwrite \
               --destination '$web/alice.zooniverse.org' \
               --source ./build
 

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -39,7 +39,7 @@ jobs:
             az storage blob upload \
               --account-name zooniversestatic \
               --content-cache-control 'public, max-age=60' \
-              --overwrite
+              --overwrite \
               --container-name '$web' \
               --name 'preview.zooniverse.org/alice/commit_id.txt' \
               --file ./build/commit_id.txt
@@ -47,7 +47,7 @@ jobs:
             az storage blob upload \
               --account-name zooniversestatic \
               --content-cache-control 'public, max-age=60' \
-              --overwrite
+              --overwrite \
               --container-name '$web' \
               --name 'preview.zooniverse.org/alice/index.html' \
               --file ./build/index.html
@@ -55,7 +55,7 @@ jobs:
             az storage blob upload-batch \
               --account-name zooniversestatic \
               --content-cache-control 'public, immutable, max-age=604800' \
-              --overwrite
+              --overwrite \
               --destination '$web/preview.zooniverse.org/alice' \
               --source ./build
 


### PR DESCRIPTION
michelle++

`--overwrite` is supposedly sufficient according to the related `az` issue, but if this still complains, I'll update it to `--overwrite true`.