### PR TITLE
Specify content-type of text/html files

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -42,6 +42,7 @@ jobs:
               --content-cache-control 'public, max-age=60' \
               --overwrite \
               --container-name '$web' \
+              --content-type 'text/plain' \
               --name 'alice.zooniverse.org/commit_id.txt' \
               --file ./build/commit_id.txt
             rm ./build/commit_id.txt
@@ -57,6 +58,7 @@ jobs:
               --account-name zooniversestatic \
               --content-cache-control 'public, immutable, max-age=604800' \
               --overwrite \
+              --content-type 'text/html' \
               --destination '$web/alice.zooniverse.org' \
               --source ./build
 

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -42,6 +42,7 @@ jobs:
               --overwrite \
               --container-name '$web' \
               --name 'preview.zooniverse.org/alice/commit_id.txt' \
+              --content-type 'text/plain' \
               --file ./build/commit_id.txt
             rm ./build/commit_id.txt
             az storage blob upload \
@@ -49,6 +50,7 @@ jobs:
               --content-cache-control 'public, max-age=60' \
               --overwrite \
               --container-name '$web' \
+              --content-type 'text/html' \
               --name 'preview.zooniverse.org/alice/index.html' \
               --file ./build/index.html
             rm ./build/index.html


### PR DESCRIPTION
The new version of the Azure CLI's `az storage blob upload` function doesn't properly detect the content type of .html or .txt files after their recent update. JS/css and media files seem unaffected, perhaps because they're using the `az storage blob upload-batch` function instead. Rather than pinning an old version, for now I'm going to ensure that specifying these types is sufficient and open an issue on their repo.