### PR TITLE
Use shared workflows for deploy & notification

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -10,7 +10,7 @@ on:
     workflow_dispatch:
 
 jobs:
-  deploy_production:
+  build_production:
     runs-on: ubuntu-latest
     env:
       HEAD_COMMIT: ${{ github.sha }}
@@ -32,75 +32,32 @@ jobs:
     - name: Write commit_id.txt
       run: echo ${HEAD_COMMIT} > ./build/commit_id.txt
 
-    - name: Upload to blob storage
-      uses: azure/CLI@v1
+    - name: Save build
+      uses: actions/upload-artifact@v2
       with:
-        creds: ${{ secrets.AZURE_STATIC_SITES }}
-        inlineScript: |
-            az storage blob upload \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, max-age=60' \
-              --container-name '$web' \
-              --name 'alice.zooniverse.org/commit_id.txt' \
-              --file ./build/commit_id.txt
-            rm ./build/commit_id.txt
-            az storage blob upload \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, max-age=60' \
-              --container-name '$web' \
-              --name 'alice.zooniverse.org/index.html' \
-              --file ./build/index.html
-            rm ./build/index.html
-            az storage blob upload-batch \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, immutable, max-age=604800' \
-              --destination '$web/alice.zooniverse.org' \
-              --source ./build
+        name: build
+        path: ./build/
 
-    - name: Slack notification
-      uses: 8398a7/action-slack@v3
-      if: always()
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      with:
-        fields: took
-        status: custom
-        custom_payload: |
-          {
-            "channel": "#deploys",
-            "icon_emoji": ":octocat:",
-            "username": "Deploy Action",
-            "attachments": [{
-              "color": '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-              "mrkdwn_in": ["text"],
-              "author_name": "${{ github.actor }}",
-              "author_link": "https://github.com/${{ github.actor }}/",
-              "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
-              "title": "ALICE Production deploy complete",
-              "title_link": "https://alice.zooniverse.org",
-              "fields": [
-                  {
-                      "title": "Status",
-                      "value": '${{ job.status }}' === 'success' ? `:white_check_mark: Success in ${process.env.AS_TOOK}` : '${{ job.status }}' === 'failure' ? ':x: Failed' : ':warning: Warning',
-                      "short": true
-                  },
-                  {
-                      "title": "Triggered by",
-                      "value": "${{ github.event_name }}",
-                      "short": true
-                  },
-                  {
-                      "title": "Run Link",
-                      "value": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  }
-              ],
-              "thumb_url": "https://raw.githubusercontent.com/zooniverse/Brand/master/style%20guide/logos/zooniverse-emblem/zooniverse-logo-teal.png",
-              "footer": "<https://github.com/${{ github.repository }}|${{ github.repository }}> #${{ github.run_number }}",
-              "footer_icon": "https://www.zooniverse.org/favicon.ico"
-            }]
-          }
+  deploy:
+    name: Deploy Production
+    uses: zooniverse/ci-cd/.github/workflows/deploy_static.yaml@main
+    needs: build_production
+    with:
+      source: 'build'
+      target: 'alice.zooniverse.org'
+    secrets:
+      creds: ${{ secrets.AZURE_STATIC_SITES }}
 
-# Azure logout
-    - name: logout
-      run: |
-            az logout
+  slack_notification:
+    name: Send Slack notification
+    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
+    needs: deploy
+    if: always()
+    with:
+      commit_id: ${{ github.sha }}
+      job_name: Deploy Production / deploy_static
+      status: ${{ needs.deploy.result }}
+      title: 'Alice Production deploy complete'
+      title_link: 'https://alice.zooniverse.org'
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build_production:
+    name: Build Production
     runs-on: ubuntu-latest
     env:
       HEAD_COMMIT: ${{ github.sha }}
@@ -55,7 +56,7 @@ jobs:
     if: always()
     with:
       commit_id: ${{ github.sha }}
-      job_name: Deploy Production / deploy_static
+      job_name: Build Production / build_production
       status: ${{ needs.deploy.result }}
       title: 'Alice Production deploy complete'
       title_link: 'https://alice.zooniverse.org'

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build_staging:
+    name: Build Staging
     runs-on: ubuntu-latest
     env:
       HEAD_COMMIT: ${{ github.sha }}
@@ -54,7 +55,7 @@ jobs:
     if: always()
     with:
       commit_id: ${{ github.sha }}
-      job_name: Deploy Staging / deploy_static
+      job_name: Build Staging / build_staging
       status: ${{ needs.deploy.result }}
       title: 'ALICE Staging deploy complete'
       title_link: 'https://preview.zooniverse.org/alice'

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -9,7 +9,7 @@ on:
     workflow_dispatch:
 
 jobs:
-  deploy_staging_branch:
+  build_staging:
     runs-on: ubuntu-latest
     env:
       HEAD_COMMIT: ${{ github.sha }}
@@ -31,75 +31,32 @@ jobs:
     - name: Write commit_id.txt
       run: echo ${HEAD_COMMIT} > ./build/commit_id.txt
 
-    - name: Upload to blob storage
-      uses: azure/CLI@v1
+    - name: Save build
+      uses: actions/upload-artifact@v2
       with:
-        creds: ${{ secrets.AZURE_STATIC_SITES }}
-        inlineScript: |
-            az storage blob upload \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, max-age=60' \
-              --container-name '$web' \
-              --name 'preview.zooniverse.org/alice/commit_id.txt' \
-              --file ./build/commit_id.txt
-            rm ./build/commit_id.txt
-            az storage blob upload \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, max-age=60' \
-              --container-name '$web' \
-              --name 'preview.zooniverse.org/alice/index.html' \
-              --file ./build/index.html
-            rm ./build/index.html
-            az storage blob upload-batch \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, immutable, max-age=604800' \
-              --destination '$web/preview.zooniverse.org/alice' \
-              --source ./build
+        name: build
+        path: ./build/
 
-    - name: Slack notification
-      uses: 8398a7/action-slack@v3
-      if: always()
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      with:
-        fields: took
-        status: custom
-        custom_payload: |
-          {
-            "channel": "#deploys",
-            "icon_emoji": ":octocat:",
-            "username": "Deploy Action",
-            "attachments": [{
-              "color": '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-              "mrkdwn_in": ["text"],
-              "author_name": "${{ github.actor }}",
-              "author_link": "https://github.com/${{ github.actor }}/",
-              "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
-              "title": "ALICE Staging deploy complete",
-              "title_link": "https://alice.preview.zooniverse.org",
-              "fields": [
-                  {
-                      "title": "Status",
-                      "value": '${{ job.status }}' === 'success' ? `:white_check_mark: Success in ${process.env.AS_TOOK}` : '${{ job.status }}' === 'failure' ? ':x: Failed' : ':warning: Warning',
-                      "short": true
-                  },
-                  {
-                      "title": "Triggered by",
-                      "value": "${{ github.event_name }}",
-                      "short": true
-                  },
-                  {
-                      "title": "Run Link",
-                      "value": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  }
-              ],
-              "thumb_url": "https://raw.githubusercontent.com/zooniverse/Brand/master/style%20guide/logos/zooniverse-emblem/zooniverse-logo-teal.png",
-              "footer": "<https://github.com/${{ github.repository }}|${{ github.repository }}> #${{ github.run_number }}",
-              "footer_icon": "https://www.zooniverse.org/favicon.ico"
-            }]
-          }
+  deploy:
+    name: Deploy Staging
+    uses: zooniverse/ci-cd/.github/workflows/deploy_static.yaml@main
+    needs: build_staging
+    with:
+      source: 'build'
+      target: 'preview.zooniverse.org/alice'
+    secrets:
+      creds: ${{ secrets.AZURE_STATIC_SITES }}
 
-# Azure logout
-    - name: logout
-      run: |
-            az logout
+  slack_notification:
+    name: Send Slack notification
+    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
+    needs: deploy
+    if: always()
+    with:
+      commit_id: ${{ github.sha }}
+      job_name: Deploy Staging / deploy_static
+      status: ${{ needs.deploy.result }}
+      title: 'ALICE Staging deploy complete'
+      title_link: 'https://preview.zooniverse.org/alice'
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This app uses yarn for building, so I left that part alone and stored the build artifact. The deploy_static and slack_notification workflows can be shared, though.