### PR TITLE
Add Video Tutorials section to about page

### DIFF
--- a/src/screens/About/About.js
+++ b/src/screens/About/About.js
@@ -10,6 +10,7 @@ import Setup from './Setup'
 import UsingAlice from './UsingAlice'
 import Acknowledgements from './Acknowledgements'
 import DataExports from './DataExports'
+import VideoTutorials from './VideoTutorials'
 
 const CapitalText = styled(Text)`
   text-transform: uppercase;
@@ -51,6 +52,7 @@ export default function About () {
         <Optics />
         <DBScan />
         <DataExports />
+        <VideoTutorials />
         <Acknowledgements />
       </Box>
     </Box>

--- a/src/screens/About/VideoTutorials.js
+++ b/src/screens/About/VideoTutorials.js
@@ -1,0 +1,92 @@
+import React from 'react'
+import { Box } from 'grommet'
+import AboutTitle from './components/AboutTitle'
+import { BodyText } from './components/Styled'
+
+export default function DataExports() {
+  return (
+    <Box gap='xsmall'>
+      <AboutTitle title='Video tutorials' />
+      <BodyText>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+      </BodyText>
+      <AboutTitle level={6} title='ALICE: Logging in & navigation' />
+      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
+        <iframe
+          src='https://player.vimeo.com/video/454881167?h=d531a65574&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+          frameBorder='0'
+          allow='autoplay; fullscreen; picture-in-picture'
+          allowFullScreen
+          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
+          title='ALICE: Logging in &amp;amp; navigation'>
+        </iframe>
+      </div>
+      <AboutTitle level={6} title='ALICE: Projects, workflows, & groups' />
+      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
+        <iframe
+          src='https://player.vimeo.com/video/454881239?h=a64d63f978&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+          frameBorder='0'
+          allow='autoplay; fullscreen; picture-in-picture'
+          allowFullScreen
+          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
+          title='ALICE: Projects, workflows, &amp;amp; groups'>
+        </iframe>
+      </div>
+      <AboutTitle level={6} title='ALICE: Sorting & searching' />
+      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
+        <iframe
+          src='https://player.vimeo.com/video/454881407?h=26bbc20c07&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+          frameBorder='0'
+          allow='autoplay; fullscreen; picture-in-picture'
+          allowFullScreen
+          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
+          title='ALICE: Sorting &amp;amp; searching'>
+        </iframe>
+      </div>
+      <AboutTitle level={6} title='ALICE: Viewing subjects' />
+      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
+        <iframe
+          src='https://player.vimeo.com/video/454861272?h=8634fa79f8&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+          frameBorder='0'
+          allow='autoplay; fullscreen; picture-in-picture'
+          allowFullScreen
+          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
+          title='ALICE: Viewing subjects'>
+        </iframe>
+      </div>
+      <AboutTitle level={6} title='ALICE: Editing & deleting transcriptions' />
+      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
+        <iframe
+          src='https://player.vimeo.com/video/454881046?h=d37680e4bc&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+          frameBorder='0'
+          allow='autoplay; fullscreen; picture-in-picture'
+          allowFullScreen
+          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
+          title='ALICE: Editing &amp;amp; deleting transcriptions'>
+        </iframe>
+      </div>
+      <AboutTitle level={6} title='ALICE: Reordering transcription lines' />
+      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
+        <iframe
+          src='https://player.vimeo.com/video/454881361?h=4c0fdbad64&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+          frameBorder='0'
+          allow='autoplay; fullscreen; picture-in-picture'
+          allowFullScreen
+          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
+          title='ALICE: Reordering transcription lines'>
+        </iframe>
+      </div>
+      <AboutTitle level={6} title='ALICE: Approving subjects' />
+      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
+        <iframe
+          src='https://player.vimeo.com/video/454880924?h=16f5d51437&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+          frameBorder='0'
+          allow='autoplay; fullscreen; picture-in-picture'
+          allowFullScreen
+          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
+          title='ALICE: Approving subjects'>
+        </iframe>
+      </div>
+    </Box>
+  )
+}

--- a/src/screens/About/VideoTutorials.js
+++ b/src/screens/About/VideoTutorials.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Box } from 'grommet'
 import AboutTitle from './components/AboutTitle'
+import VimeoEmbed from './components/VimeoEmbed'
 import { BodyText } from './components/Styled'
 
 export default function DataExports() {
@@ -11,82 +12,40 @@ export default function DataExports() {
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
       </BodyText>
       <AboutTitle level={6} title='ALICE: Logging in & navigation' />
-      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
-        <iframe
-          src='https://player.vimeo.com/video/454881167?h=d531a65574&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
-          frameBorder='0'
-          allow='autoplay; fullscreen; picture-in-picture'
-          allowFullScreen
-          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
-          title='ALICE: Logging in &amp;amp; navigation'>
-        </iframe>
-      </div>
+      <VimeoEmbed
+        src='https://player.vimeo.com/video/454881167?h=d531a65574&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+        title='ALICE: Logging in &amp;amp; navigation'
+      />
       <AboutTitle level={6} title='ALICE: Projects, workflows, & groups' />
-      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
-        <iframe
-          src='https://player.vimeo.com/video/454881239?h=a64d63f978&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
-          frameBorder='0'
-          allow='autoplay; fullscreen; picture-in-picture'
-          allowFullScreen
-          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
-          title='ALICE: Projects, workflows, &amp;amp; groups'>
-        </iframe>
-      </div>
+      <VimeoEmbed
+        src='https://player.vimeo.com/video/454881239?h=a64d63f978&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+          title='ALICE: Projects, workflows, &amp;amp; groups'
+      />
       <AboutTitle level={6} title='ALICE: Sorting & searching' />
-      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
-        <iframe
-          src='https://player.vimeo.com/video/454881407?h=26bbc20c07&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
-          frameBorder='0'
-          allow='autoplay; fullscreen; picture-in-picture'
-          allowFullScreen
-          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
-          title='ALICE: Sorting &amp;amp; searching'>
-        </iframe>
-      </div>
+      <VimeoEmbed
+        src='https://player.vimeo.com/video/454881407?h=26bbc20c07&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+        title='ALICE: Sorting &amp;amp; searching'
+      />
       <AboutTitle level={6} title='ALICE: Viewing subjects' />
-      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
-        <iframe
-          src='https://player.vimeo.com/video/454861272?h=8634fa79f8&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
-          frameBorder='0'
-          allow='autoplay; fullscreen; picture-in-picture'
-          allowFullScreen
-          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
-          title='ALICE: Viewing subjects'>
-        </iframe>
-      </div>
+      <VimeoEmbed
+        src='https://player.vimeo.com/video/454861272?h=8634fa79f8&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+        title='ALICE: Viewing subjects'
+      />
       <AboutTitle level={6} title='ALICE: Editing & deleting transcriptions' />
-      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
-        <iframe
-          src='https://player.vimeo.com/video/454881046?h=d37680e4bc&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
-          frameBorder='0'
-          allow='autoplay; fullscreen; picture-in-picture'
-          allowFullScreen
-          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
-          title='ALICE: Editing &amp;amp; deleting transcriptions'>
-        </iframe>
-      </div>
+      <VimeoEmbed
+        src='https://player.vimeo.com/video/454881046?h=d37680e4bc&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+        title='ALICE: Editing &amp;amp; deleting transcriptions'
+      />
       <AboutTitle level={6} title='ALICE: Reordering transcription lines' />
-      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
-        <iframe
-          src='https://player.vimeo.com/video/454881361?h=4c0fdbad64&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
-          frameBorder='0'
-          allow='autoplay; fullscreen; picture-in-picture'
-          allowFullScreen
-          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
-          title='ALICE: Reordering transcription lines'>
-        </iframe>
-      </div>
+      <VimeoEmbed
+        src='https://player.vimeo.com/video/454881361?h=4c0fdbad64&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+        title='ALICE: Reordering transcription lines'
+      />
       <AboutTitle level={6} title='ALICE: Approving subjects' />
-      <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
-        <iframe
-          src='https://player.vimeo.com/video/454880924?h=16f5d51437&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
-          frameBorder='0'
-          allow='autoplay; fullscreen; picture-in-picture'
-          allowFullScreen
-          style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
-          title='ALICE: Approving subjects'>
-        </iframe>
-      </div>
+      <VimeoEmbed
+        src='https://player.vimeo.com/video/454880924?h=16f5d51437&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479'
+        title='ALICE: Approving subjects'
+      />
     </Box>
   )
 }

--- a/src/screens/About/VideoTutorials.spec.js
+++ b/src/screens/About/VideoTutorials.spec.js
@@ -1,0 +1,10 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import VideoTutorials from './VideoTutorials'
+
+describe('Component > VideoTutorials', function () {
+  it('should render without crashing', function () {
+    const wrapper = shallow(<VideoTutorials />);
+    expect(wrapper).toBeDefined()
+  })
+})

--- a/src/screens/About/components/VimeoEmbed.js
+++ b/src/screens/About/components/VimeoEmbed.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { string } from 'prop-types'
+
+export default function VimeoEmbed({ src, title }) {
+  return (
+    <div style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
+      <iframe
+        src={src}
+        frameBorder='0'
+        allow='autoplay; fullscreen; picture-in-picture'
+        allowFullScreen
+        style={{ position: 'absolute', top: '0', left: '0', width: '100%', height: '100%' }}
+        title={title}
+      />
+    </div>
+  )
+}
+
+VimeoEmbed.propTypes = {
+  src: string.isRequired,
+  title: string.isRequired
+}

--- a/src/screens/About/components/VimeoEmbed.spec.js
+++ b/src/screens/About/components/VimeoEmbed.spec.js
@@ -1,0 +1,10 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import VimeoEmbed from './VimeoEmbed'
+
+describe('Component > VimeoEmbed', function () {
+  it('should render without crashing', function () {
+    const wrapper = shallow(<VimeoEmbed src='test src' title='test title' />);
+    expect(wrapper).toBeDefined()
+  })
+})

--- a/src/screens/About/contents.js
+++ b/src/screens/About/contents.js
@@ -54,7 +54,24 @@ const contents = [{
     }]
   },{
     title: 'Data exports'
-  }, {
+  },{
+    title: 'Video tutorials',
+    sub: [{
+      title: 'ALICE: Logging in & navigation'
+    },{
+      title: 'ALICE: Projects, workflows, & groups'
+    },{
+      title: 'ALICE: Sorting & searching'
+    },{
+      title: 'ALICE: Viewing subjects'
+    },{
+      title: 'ALICE: Editing & deleting transcriptions'
+    },{
+      title: 'ALICE: Reordering transcription lines'
+    },{
+      title: 'ALICE: Approving subjects'
+    }]
+  },{
     title: 'Acknowledgements'
   }]
 }]


### PR DESCRIPTION
Closes #253.

Adds video tutorials noted in linked issue to a new About page Video Tutorials section, with VimeoEmbed component. Video titles are listed in and linked in side menu bar (src/screens/About/contents.js).

Section description currently placeholder text, to be edited or deleted.