### PR TITLE
Remove global variables from tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --coverage --watchAll=false --silent",
+    "test:debug": "react-scripts --inspect test --runInBand --no-cache",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/src/components/AggregatedTranscriptions/AggregatedTranscriptionsContainer.spec.js
+++ b/src/components/AggregatedTranscriptions/AggregatedTranscriptionsContainer.spec.js
@@ -2,18 +2,18 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import AggregatedTranscriptionsContainer from './AggregatedTranscriptionsContainer'
 
-const addLineSpy = jest.fn()
-const context = {
-  aggregations: {},
-  projects: { isViewer: false },
-  transcriptions: {
-    activeTranscriptionIndex: 0,
-    addLine: addLineSpy
-  }
-}
-let wrapper
-
 describe('Component > AggregatedTranscriptionsContainer', function () {
+  const addLineSpy = jest.fn()
+  const context = {
+    aggregations: {},
+    projects: { isViewer: false },
+    transcriptions: {
+      activeTranscriptionIndex: 0,
+      addLine: addLineSpy
+    }
+  }
+  let wrapper
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/Flags.spec.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/Flags.spec.js
@@ -3,12 +3,12 @@ import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Flags, StyledFontAwesomeIcon } from './Flags'
 
-let wrapper
-const reviewedDatum = { seen: true }
-const flaggedDatum = { flagged: true }
-const goldStandardDatum = { goldStandard: true }
-
 describe('Component > Flags', function () {
+  let wrapper
+  const reviewedDatum = { seen: true }
+  const flaggedDatum = { flagged: true }
+  const goldStandardDatum = { goldStandard: true }
+
   it('should render without crashing', function () {
     wrapper = shallow(<Flags />);
     expect(wrapper).toBeDefined()

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.spec.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.spec.js
@@ -4,11 +4,11 @@ import mockData from './mockData'
 import TranscriptionTable from './TranscriptionTable'
 import TranscriptionTableRow from './TranscriptionTableRow'
 
-let wrapper;
-let useStateSpy;
-let setState = jest.fn()
-
 describe('Component > TranscriptionTable', function () {
+  let wrapper;
+  let useStateSpy;
+  let setState = jest.fn()
+
   beforeEach(function() {
     useStateSpy = jest.spyOn(React, 'useState')
     useStateSpy.mockImplementation((init) => [init, setState])

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableContainer.spec.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableContainer.spec.js
@@ -2,24 +2,24 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import TranscriptionTableContainer from './TranscriptionTableContainer'
 
-let wrapper
-const setActiveTranscriptionSpy = jest.fn()
-const contextValues = {
-  projects: {
-    isViewer: false
-  },
-  subjects: {
-    index: 0
-  },
-  transcriptions: {
-    current: {
-      text: new Map()
-    },
-    setActiveTranscription: setActiveTranscriptionSpy
-  }
-}
-
 describe('Component > TranscriptionTableContainer', function () {
+  let wrapper
+  const setActiveTranscriptionSpy = jest.fn()
+  const contextValues = {
+    projects: {
+      isViewer: false
+    },
+    subjects: {
+      index: 0
+    },
+    transcriptions: {
+      current: {
+        text: new Map()
+      },
+      setActiveTranscription: setActiveTranscriptionSpy
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableRow.spec.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableRow.spec.js
@@ -7,21 +7,21 @@ import mockData from './mockData'
 import renderer from 'react-test-renderer'
 import 'jest-styled-components'
 
-let pointerBox;
-let wrapper;
-let useStateSpy;
-
-const preventDefaultSpy = jest.fn();
-let setActiveTranscriptionSpy = jest.fn();
-let setDragIDSpy = jest.fn();
-let moveDataSpy = jest.fn();
-let setState = jest.fn();
-let setTextObjectSpy = jest.fn();
-const stopPropagationSpy = jest.fn();
-
-const mockEvent = { preventDefault: preventDefaultSpy, stopPropagation: stopPropagationSpy }
-
 describe('Component > TranscriptionTable', function () {
+  let pointerBox;
+  let wrapper;
+  let useStateSpy;
+
+  const preventDefaultSpy = jest.fn();
+  let setActiveTranscriptionSpy = jest.fn();
+  let setDragIDSpy = jest.fn();
+  let moveDataSpy = jest.fn();
+  let setState = jest.fn();
+  let setTextObjectSpy = jest.fn();
+  const stopPropagationSpy = jest.fn();
+
+  const mockEvent = { preventDefault: preventDefaultSpy, stopPropagation: stopPropagationSpy }
+
   beforeEach(function() {
     useStateSpy = jest.spyOn(React, 'useState')
     useStateSpy.mockImplementation((init) => [init, setState])

--- a/src/components/AggregationSettings/AggregationModal.spec.js
+++ b/src/components/AggregationSettings/AggregationModal.spec.js
@@ -3,25 +3,25 @@ import React from 'react'
 import { act } from 'react-dom/test-utils';
 import AggregationModal from './AggregationModal'
 
-let wrapper
-const contextValues = {
-  transcriptions: {
-    current: {
-      reducer: '',
-      parameters: {}
+describe('Component > AggregationModal', function () {
+  let wrapper
+  const contextValues = {
+    transcriptions: {
+      current: {
+        reducer: '',
+        parameters: {}
+      }
     }
   }
-}
 
-const refStub = React.createRef()
-refStub.current = { getBoundingClientRect: () => {
-  return {
-    top: 50,
-    width: 100
-  }
-} }
+  const refStub = React.createRef()
+  refStub.current = { getBoundingClientRect: () => {
+    return {
+      top: 50,
+      width: 100
+    }
+  } }
 
-describe('Component > AggregationModal', function () {
   beforeEach(async function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/AggregationSettings/AggregationSettings.spec.js
+++ b/src/components/AggregationSettings/AggregationSettings.spec.js
@@ -8,10 +8,10 @@ import OpticsReducer from './OpticsReducer'
 import ChooseReducer from './ChooseReducer'
 import Confirmation from './Confirmation'
 
-let wrapper
-let closeContainerSpy = jest.fn()
-
 describe('Component > AggregationSettings', function () {
+  let wrapper
+  let closeContainerSpy = jest.fn()
+
   beforeEach(function() {
     wrapper = shallow(
       <AggregationSettings

--- a/src/components/AggregationSettings/AggregationSettingsContainer.spec.js
+++ b/src/components/AggregationSettings/AggregationSettingsContainer.spec.js
@@ -2,25 +2,25 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import { AggregationSettingsContainer } from './AggregationSettingsContainer'
 
-let wrapper
-const reaggregateDBScanSpy = jest.fn()
-const reaggregateOpticsSpy = jest.fn()
-const toggleModalSpy = jest.fn()
-const contextValues = {
-  aggregations: {
-    toggleModal: toggleModalSpy
-  },
-  transcriptions: {
-    current: {
-      reducer: '',
-      parameters: {}
-    },
-    reaggregateOptics: reaggregateOpticsSpy,
-    reaggregateDBScan: reaggregateDBScanSpy,
-  }
-}
-
 describe('Component > AggregationSettingsContainer', function () {
+  let wrapper
+  const reaggregateDBScanSpy = jest.fn()
+  const reaggregateOpticsSpy = jest.fn()
+  const toggleModalSpy = jest.fn()
+  const contextValues = {
+    aggregations: {
+      toggleModal: toggleModalSpy
+    },
+    transcriptions: {
+      current: {
+        reducer: '',
+        parameters: {}
+      },
+      reaggregateOptics: reaggregateOpticsSpy,
+      reaggregateDBScan: reaggregateDBScanSpy,
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/AggregationSettings/ChooseReducer.spec.js
+++ b/src/components/AggregationSettings/ChooseReducer.spec.js
@@ -6,9 +6,9 @@ import { REDUCERS } from './AggregationSettingsContainer'
 import renderer from 'react-test-renderer'
 import 'jest-styled-components'
 
-let wrapper
-
 describe('Component > ChooseReducer', function () {
+  let wrapper
+
   beforeEach(function() {
     wrapper = shallow(<ChooseReducer />);
   })

--- a/src/components/AggregationSettings/Confirmation.spec.js
+++ b/src/components/AggregationSettings/Confirmation.spec.js
@@ -3,9 +3,9 @@ import React from 'react'
 import { Button } from 'grommet'
 import Confirmation from './Confirmation'
 
-let wrapper
-
 describe('Component > Confirmation', function () {
+  let wrapper
+
   beforeEach(function() {
     wrapper = shallow(<Confirmation />);
   })

--- a/src/components/AggregationSettings/DBScanReducer.spec.js
+++ b/src/components/AggregationSettings/DBScanReducer.spec.js
@@ -5,31 +5,31 @@ import { Formik } from 'formik'
 import { REDUCERS } from './AggregationSettingsContainer'
 import DBScanReducer from './DBScanReducer'
 
-let form
-let wrapper
-let setCallbackSpy = jest.fn()
-let setScreenSpy = jest.fn()
-const error = 'This is an error'
-
-const initialValues = {
-  epsSlope: 25,
-  epsLine: 40,
-  epsWord: 40,
-  gutterTol: 0,
-  minSamples: 1,
-  minWordCount: 1
-}
-
-const errors = {
-  epsSlope: error,
-  epsLine: error,
-  epsWord: error,
-  gutterTol: error,
-  minSamples: error,
-  minWordCount: error
-}
-
 describe('Component > DBScanReducer', function () {
+  let form
+  let wrapper
+  let setCallbackSpy = jest.fn()
+  let setScreenSpy = jest.fn()
+  const error = 'This is an error'
+
+  const initialValues = {
+    epsSlope: 25,
+    epsLine: 40,
+    epsWord: 40,
+    gutterTol: 0,
+    minSamples: 1,
+    minWordCount: 1
+  }
+
+  const errors = {
+    epsSlope: error,
+    epsLine: error,
+    epsWord: error,
+    gutterTol: error,
+    minSamples: error,
+    minWordCount: error
+  }
+
   beforeEach(function() {
     wrapper = shallow(<DBScanReducer setCallback={setCallbackSpy} setScreen={setScreenSpy} />);
   })

--- a/src/components/AggregationSettings/OpticsReducer.spec.js
+++ b/src/components/AggregationSettings/OpticsReducer.spec.js
@@ -5,31 +5,31 @@ import { Formik } from 'formik'
 import { REDUCERS } from './AggregationSettingsContainer'
 import OpticsReducer from './OpticsReducer'
 
-let form
-let wrapper
-let setCallbackSpy = jest.fn()
-let setScreenSpy = jest.fn()
-const error = 'This is an error'
-
-const initialValues = {
-  angleEps: 30,
-  auto: false,
-  gutterEps: 150,
-  minLineLength: 0,
-  minSamples: 2,
-  xi: 0.05
-}
-
-const errors = {
-  angleEps: error,
-  auto: error,
-  gutterEps: error,
-  minLineLength: error,
-  minSamples: error,
-  xi: error
-}
-
 describe('Component > OpticsReducer', function () {
+  let form
+  let wrapper
+  let setCallbackSpy = jest.fn()
+  let setScreenSpy = jest.fn()
+  const error = 'This is an error'
+
+  const initialValues = {
+    angleEps: 30,
+    auto: false,
+    gutterEps: 150,
+    minLineLength: 0,
+    minSamples: 2,
+    xi: 0.05
+  }
+
+  const errors = {
+    angleEps: error,
+    auto: error,
+    gutterEps: error,
+    minLineLength: error,
+    minSamples: error,
+    xi: error
+  }
+
   beforeEach(function() {
     wrapper = shallow(<OpticsReducer setCallback={setCallbackSpy} setScreen={setScreenSpy} />);
   })

--- a/src/components/Badge/Badge.spec.js
+++ b/src/components/Badge/Badge.spec.js
@@ -7,10 +7,10 @@ import 'jest-styled-components'
 import Badge, { DropLink, StyledAvatar, StyledBox } from './Badge'
 import DefaultAvatar from '../../images/user.svg'
 
-let wrapper
-const setOpenSpy = jest.fn()
-
 describe('Component > Badge', function () {
+  let wrapper
+  const setOpenSpy = jest.fn()
+
   it('should render without crashing', function () {
     wrapper = shallow(<Badge setOpen={setOpenSpy} />);
     expect(wrapper).toBeDefined()

--- a/src/components/Badge/BadgeContainer.spec.js
+++ b/src/components/Badge/BadgeContainer.spec.js
@@ -3,30 +3,30 @@ import React from 'react'
 import BadgeContainer from './BadgeContainer'
 import Badge from './Badge'
 
-let wrapper
-let badgeComponent
-const logoutSpy = jest.fn()
-const unlockTranscriptionSpy = jest.fn()
-
-const contextValues = {
-  aggregations: {
-    showModal: false
-  },
-  auth: {
-    logout: logoutSpy,
-    user: { avatar_src: 'source.jpg' },
-    userName: 'Test_User'
-  },
-  projects: {
-    role: 'Researcher'
-  },
-  transcriptions: {
-    isActive: false,
-    unlockTranscription: unlockTranscriptionSpy
-  }
-}
-
 describe('Component > BadgeContainer', function () {
+  let wrapper
+  let badgeComponent
+  const logoutSpy = jest.fn()
+  const unlockTranscriptionSpy = jest.fn()
+
+  const contextValues = {
+    aggregations: {
+      showModal: false
+    },
+    auth: {
+      logout: logoutSpy,
+      user: { avatar_src: 'source.jpg' },
+      userName: 'Test_User'
+    },
+    projects: {
+      role: 'Researcher'
+    },
+    transcriptions: {
+      isActive: false,
+      unlockTranscription: unlockTranscriptionSpy
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/EditorHeader/EditorHeader.spec.js
+++ b/src/components/EditorHeader/EditorHeader.spec.js
@@ -5,10 +5,10 @@ import EditorHeader from './EditorHeader'
 import Back from './components/Back'
 import MarkApproved from './components/MarkApproved'
 
-let wrapper
-const user = { id: '1' }
-
 describe('Component > EditorHeader', function () {
+  let wrapper
+  const user = { id: '1' }
+
   it('should render without crashing', function () {
     wrapper = shallow(<EditorHeader />);
     expect(wrapper).toBeDefined()

--- a/src/components/EditorHeader/EditorHeaderContainer.spec.js
+++ b/src/components/EditorHeader/EditorHeaderContainer.spec.js
@@ -9,33 +9,33 @@ import LayoutButton from './components/HeaderButton/LayoutButtonContainer'
 import MoreButton from './components/MoreButton'
 import { EDIT_PATH, PROJECTS_PATH, SUBJECTS_PATH } from 'paths'
 
-let wrapper
-const contextValues = {
-  aggregations: {
-    showModal: false
-  },
-  auth: {
-    user: { id: '1' }
-  },
-  projects: {
-    isViewer: false
-  },
-  transcriptions: {
-    approved: false
-  }
-}
-const EDIT_PATH_HISTORY = {
-  location: {
-    pathname: EDIT_PATH
-  }
-}
-const SUBJECTS_PATH_HISTORY = {
-  location: {
-    pathname: SUBJECTS_PATH
-  }
-}
-
 describe('Component > EditorHeaderContainer', function () {
+  let wrapper
+  const contextValues = {
+    aggregations: {
+      showModal: false
+    },
+    auth: {
+      user: { id: '1' }
+    },
+    projects: {
+      isViewer: false
+    },
+    transcriptions: {
+      approved: false
+    }
+  }
+  const EDIT_PATH_HISTORY = {
+    location: {
+      pathname: EDIT_PATH
+    }
+  }
+  const SUBJECTS_PATH_HISTORY = {
+    location: {
+      pathname: SUBJECTS_PATH
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/EditorHeader/components/Back/Back.spec.js
+++ b/src/components/EditorHeader/components/Back/Back.spec.js
@@ -2,10 +2,10 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import Back from './Back'
 
-let wrapper
-const user = { id: '1' };
-
 describe('Component > Back', function () {
+  let wrapper
+  const user = { id: '1' };
+
   beforeEach(function() {
     wrapper = shallow(<Back />);
   })

--- a/src/components/EditorHeader/components/HeaderButton/DownloadSetDataContainer.spec.js
+++ b/src/components/EditorHeader/components/HeaderButton/DownloadSetDataContainer.spec.js
@@ -2,18 +2,18 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import DownloadSetDataContainer from './DownloadSetDataContainer'
 
-let wrapper
-const toggleModalSpy = jest.fn()
-const contextValues = {
-  modal: {
-    toggleModal: toggleModalSpy
-  },
-  transcriptions: {
-    approvedCount: 5
-  }
-}
-
 describe('Component > DownloadSetDataContainer', function () {
+  let wrapper
+  const toggleModalSpy = jest.fn()
+  const contextValues = {
+    modal: {
+      toggleModal: toggleModalSpy
+    },
+    transcriptions: {
+      approvedCount: 5
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/EditorHeader/components/HeaderButton/HeaderButton.spec.js
+++ b/src/components/EditorHeader/components/HeaderButton/HeaderButton.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import HeaderButton from './HeaderButton'
 
-let wrapper
-
 describe('Component > HeaderButton', function () {
+  let wrapper
+
   beforeEach(function() {
     wrapper = shallow(<HeaderButton />);
   })

--- a/src/components/EditorHeader/components/HeaderButton/LayoutButtonContainer.spec.js
+++ b/src/components/EditorHeader/components/HeaderButton/LayoutButtonContainer.spec.js
@@ -2,15 +2,15 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import LayoutButtonContainer from './LayoutButtonContainer'
 
-let wrapper
-const toggleLayoutSpy = jest.fn()
-const contextValues = {
-  editor: {
-    toggleLayout: toggleLayoutSpy
-  }
-}
-
 describe('Component > UndoButton', function () {
+  let wrapper
+  const toggleLayoutSpy = jest.fn()
+  const contextValues = {
+    editor: {
+      toggleLayout: toggleLayoutSpy
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/EditorHeader/components/HeaderButton/SearchButtonContainer.spec.js
+++ b/src/components/EditorHeader/components/HeaderButton/SearchButtonContainer.spec.js
@@ -3,15 +3,15 @@ import React from 'react'
 import MODALS from 'helpers/modals'
 import SearchButtonContainer from './SearchButtonContainer'
 
-let wrapper
-let toggleModalSpy = jest.fn()
-const contextValues = {
-  modal: {
-    toggleModal: toggleModalSpy,
-  }
-}
-
 describe('Component > SearchButtonContainer', function () {
+  let wrapper
+  let toggleModalSpy = jest.fn()
+  const contextValues = {
+    modal: {
+      toggleModal: toggleModalSpy,
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/EditorHeader/components/HeaderButton/UndoButtonContainer.spec.js
+++ b/src/components/EditorHeader/components/HeaderButton/UndoButtonContainer.spec.js
@@ -2,15 +2,15 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import UndoButtonContainer from './UndoButtonContainer'
 
-let wrapper
-const undoSpy = jest.fn()
-const context = {
-  transcriptions: {
-    undo: undoSpy
-  }
-}
-
 describe('Component > UndoButton', function () {
+  let wrapper
+  const undoSpy = jest.fn()
+  const context = {
+    transcriptions: {
+      undo: undoSpy
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/EditorHeader/components/MarkApproved/MarkApproved.spec.js
+++ b/src/components/EditorHeader/components/MarkApproved/MarkApproved.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import { MarkApproved } from './MarkApproved'
 
-let wrapper
-
 describe('Component > MarkApproved', function () {
+  let wrapper
+
   beforeEach(function() {
     wrapper = shallow(<MarkApproved isAdmin />);
   })

--- a/src/components/EditorHeader/components/MarkApproved/MarkApprovedContainer.spec.js
+++ b/src/components/EditorHeader/components/MarkApproved/MarkApprovedContainer.spec.js
@@ -3,24 +3,24 @@ import React from 'react'
 import MODALS from 'helpers/modals'
 import MarkApprovedContainer from './MarkApprovedContainer'
 
-let wrapper
-const toggleModalSpy = jest.fn()
-const updateApprovalSpy = jest.fn()
-const contextValues = {
-  modal: {
-    toggleModal: toggleModalSpy
-  },
-  projects: {
-    isAdmin: false
-  },
-  transcriptions: {
-    approved: true,
-    readyForReview: false,
-    updateApproval: updateApprovalSpy
-  }
-}
-
 describe('Component > MarkApprovedContainer', function () {
+  let wrapper
+  const toggleModalSpy = jest.fn()
+  const updateApprovalSpy = jest.fn()
+  const contextValues = {
+    modal: {
+      toggleModal: toggleModalSpy
+    },
+    projects: {
+      isAdmin: false
+    },
+    transcriptions: {
+      approved: true,
+      readyForReview: false,
+      updateApproval: updateApprovalSpy
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/EditorHeader/components/MetadataButton/MetadataButton.spec.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButton.spec.js
@@ -4,9 +4,9 @@ import { Button } from 'grommet'
 import { MetadataButton } from './MetadataButton'
 import mockMetadata from './mockMetadata'
 
-let wrapper
-
 describe('Component > MetadataButton', function () {
+  let wrapper
+
   beforeEach(function() {
     wrapper = shallow(<MetadataButton />);
   })

--- a/src/components/EditorHeader/components/MetadataButton/MetadataButtonContainer.spec.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButtonContainer.spec.js
@@ -3,25 +3,25 @@ import React from 'react'
 import STATUS from 'helpers/status'
 import MetadataButtonContainer from './MetadataButtonContainer'
 
-let wrapper
-const contextValues = {
-  aggregations: {
-    showModal: false
-  },
-  subjects: {
-    current: {
-      id: '1',
-      metadata: {}
-    }
-  },
-  transcriptions: {
-    current: {
-      status: STATUS.APPROVED
+describe('Component > MetadataButtonContainer', function () {
+  let wrapper
+  const contextValues = {
+    aggregations: {
+      showModal: false
+    },
+    subjects: {
+      current: {
+        id: '1',
+        metadata: {}
+      }
+    },
+    transcriptions: {
+      current: {
+        status: STATUS.APPROVED
+      }
     }
   }
-}
 
-describe('Component > MetadataButtonContainer', function () {
   beforeEach(function() {
     jest.spyOn(React, 'useContext').mockImplementation((context) => contextValues)
     wrapper = shallow(<MetadataButtonContainer />);

--- a/src/components/EditorHeader/components/MoreButton/MoreButton.spec.js
+++ b/src/components/EditorHeader/components/MoreButton/MoreButton.spec.js
@@ -2,17 +2,17 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import MoreButton from './MoreButton'
 
-let wrapper
-let setOpenSpy = jest.fn()
-let toggleDownloadSpy = jest.fn()
-let toggleModalSpy = jest.fn()
-const contextValues = {
-  aggregations: {
-    toggleModal: toggleModalSpy
-  }
-}
-
 describe('Component > UndoButton', function () {
+  let wrapper
+  let setOpenSpy = jest.fn()
+  let toggleDownloadSpy = jest.fn()
+  let toggleModalSpy = jest.fn()
+  const contextValues = {
+    aggregations: {
+      toggleModal: toggleModalSpy
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/EditorHeader/components/MoreButton/MoreButtonContainer.spec.js
+++ b/src/components/EditorHeader/components/MoreButton/MoreButtonContainer.spec.js
@@ -3,21 +3,21 @@ import React from 'react'
 import MODALS from 'helpers/modals'
 import MoreButtonContainer from './MoreButtonContainer'
 
-let wrapper
-const toggleModalSpy = jest.fn()
-const contextValues = {
-  aggregations: {
-    showModal: false
-  },
-  modal: {
-    toggleModal: toggleModalSpy
-  },
-  transcriptions: {
-    approved: false
-  }
-}
-
 describe('Component > UndoButton', function () {
+  let wrapper
+  const toggleModalSpy = jest.fn()
+  const contextValues = {
+    aggregations: {
+      showModal: false
+    },
+    modal: {
+      toggleModal: toggleModalSpy
+    },
+    transcriptions: {
+      approved: false
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/EditorHeader/components/SaveStatus/SaveStatus.spec.js
+++ b/src/components/EditorHeader/components/SaveStatus/SaveStatus.spec.js
@@ -3,9 +3,9 @@ import React from 'react'
 import ASYNC_STATES from 'helpers/asyncStates'
 import { SaveStatus } from './SaveStatus'
 
-let wrapper
-
 describe('Component > SaveStatus', function () {
+  let wrapper
+
   it('should render without crashing', function () {
     wrapper = shallow(<SaveStatus />);
     expect(wrapper).toBeDefined()

--- a/src/components/EditorHeader/components/SaveStatus/SaveStatusContainer.spec.js
+++ b/src/components/EditorHeader/components/SaveStatus/SaveStatusContainer.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import SaveStatusContainer from './SaveStatusContainer'
 
-let wrapper
-
 describe('Component > SaveStatusContainer', function () {
+  let wrapper
+
   beforeEach(function() {
     wrapper = shallow(<SaveStatusContainer />);
   })

--- a/src/components/EditorHeader/components/Title/Title.spec.js
+++ b/src/components/EditorHeader/components/Title/Title.spec.js
@@ -3,39 +3,39 @@ import React from 'react'
 import { Button } from 'grommet'
 import { CapitalText, StyledHeading, Title } from './Title'
 
-let wrapper
-const editContext = {
-  aggregations: {
-    showModal: false
-  },
-  projects: {
-    title: 'Project'
-  },
-  workflows: {
-    title: 'Workflow'
-  },
-  groups: {
-    title: 'Group'
-  },
-  transcriptions: {
-    approvedCount: 0,
-    all: { size: 0 },
-    title: 'Subject',
-    totalCount: 100
-  }
-}
-
-const pushSpy = jest.fn()
-
-const history = {
-  location: {
-    pathname: '/projects/123/workflows/123/groups/4/subjects'
-  },
-  push: pushSpy
-}
-
 
 describe('Component > Title', function () {
+  let wrapper
+  const editContext = {
+    aggregations: {
+      showModal: false
+    },
+    projects: {
+      title: 'Project'
+    },
+    workflows: {
+      title: 'Workflow'
+    },
+    groups: {
+      title: 'Group'
+    },
+    transcriptions: {
+      approvedCount: 0,
+      all: { size: 0 },
+      title: 'Subject',
+      totalCount: 100
+    }
+  }
+
+  const pushSpy = jest.fn()
+
+  const history = {
+    location: {
+      pathname: '/projects/123/workflows/123/groups/4/subjects'
+    },
+    push: pushSpy
+  }
+
   beforeEach(function() {
     wrapper = shallow(<Title />);
   })

--- a/src/components/FilmstripViewer/FilmstripViewer.spec.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.spec.js
@@ -12,19 +12,19 @@ import FilmstripThumbnail from './components/FilmstripThumbnail'
 import StepNavigation from '../StepNavigation'
 import Overlay from '../Overlay'
 
-let wrapper;
-const slopeDefinitions = {
-  'frame0.0': '0',
-  'frame1.0': '90',
-  'frame2.0': '0',
-  'frame3.0': '0',
-  'frame4.0': '0',
-  'frame5.0': '0',
-}
-
-const slopeKeys = ['frame0.0', 'frame1.0', 'frame2.0', 'frame3.0', 'frame4.0', 'frame5.0']
-
 describe('Component > FilmstripViewer', function () {
+  let wrapper;
+  const slopeDefinitions = {
+    'frame0.0': '0',
+    'frame1.0': '90',
+    'frame2.0': '0',
+    'frame3.0': '0',
+    'frame4.0': '0',
+    'frame5.0': '0',
+  }
+
+  const slopeKeys = ['frame0.0', 'frame1.0', 'frame2.0', 'frame3.0', 'frame4.0', 'frame5.0']
+
   beforeEach(function() {
     wrapper = mount(
       <FilmstripViewer

--- a/src/components/FilmstripViewer/FilmstripViewerContainer.spec.js
+++ b/src/components/FilmstripViewer/FilmstripViewerContainer.spec.js
@@ -3,21 +3,21 @@ import React from 'react'
 import STATUS from 'helpers/status'
 import FilmstripViewerContainer from './FilmstripViewerContainer'
 
-let wrapper
-const resetSpy = jest.fn()
-const changeIndexSpy = jest.fn()
-const setActiveTranscriptionSpy = jest.fn()
-
-const contextValues = {
-  aggregations: { showModal: false },
-  image: { reset: resetSpy },
-  transcriptions: {
-    changeIndex: changeIndexSpy,
-    setActiveTranscription: setActiveTranscriptionSpy
-  }
-}
-
 describe('Component > FilmstripViewerContainer', function () {
+  let wrapper
+  const resetSpy = jest.fn()
+  const changeIndexSpy = jest.fn()
+  const setActiveTranscriptionSpy = jest.fn()
+
+  const contextValues = {
+    aggregations: { showModal: false },
+    image: { reset: resetSpy },
+    transcriptions: {
+      changeIndex: changeIndexSpy,
+      setActiveTranscription: setActiveTranscriptionSpy
+    }
+  }
+
   it('should render without crashing', function () {
     wrapper = shallow(<FilmstripViewerContainer />);
     expect(wrapper).toBeDefined()
@@ -35,6 +35,11 @@ describe('Component > FilmstripViewerContainer', function () {
 })
 
 describe('Context > FilmstripViewerContainer', function () {
+  let wrapper
+  const resetSpy = jest.fn()
+  const changeIndexSpy = jest.fn()
+  const setActiveTranscriptionSpy = jest.fn()
+
   describe('with an approved subject', function () {
     it('should set the draggable prop to false', function () {
       const approvedContext = {

--- a/src/components/FilmstripViewer/FilmstripViewerContainer.spec.js
+++ b/src/components/FilmstripViewer/FilmstripViewerContainer.spec.js
@@ -40,6 +40,15 @@ describe('Context > FilmstripViewerContainer', function () {
   const changeIndexSpy = jest.fn()
   const setActiveTranscriptionSpy = jest.fn()
 
+  const contextValues = {
+    aggregations: { showModal: false },
+    image: { reset: resetSpy },
+    transcriptions: {
+      changeIndex: changeIndexSpy,
+      setActiveTranscription: setActiveTranscriptionSpy
+    }
+  }
+
   describe('with an approved subject', function () {
     it('should set the draggable prop to false', function () {
       const approvedContext = {

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.spec.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.spec.js
@@ -4,20 +4,20 @@ import renderer from 'react-test-renderer'
 import 'jest-styled-components'
 import FilmstripThumbnail, { StyledButton } from './FilmstripThumbnail'
 
-const preventDefaultSpy = jest.fn()
-const rearrangePagesSpy = jest.fn()
-const setHoveredIndexSpy = jest.fn()
-const setSlopeValues = jest.fn()
-const selectImage = jest.fn()
-const setStateSpy = jest.fn()
-const slopeValues = ['frame0', 'frame1', 'frame2']
-const stopPropagationSpy = jest.fn()
-const mockEvent = { preventDefault: preventDefaultSpy, stopPropagation: stopPropagationSpy }
-
-let button
-let wrapper
-
 describe('Component > FilmstripViewer', function () {
+  const preventDefaultSpy = jest.fn()
+  const rearrangePagesSpy = jest.fn()
+  const setHoveredIndexSpy = jest.fn()
+  const setSlopeValues = jest.fn()
+  const selectImage = jest.fn()
+  const setStateSpy = jest.fn()
+  const slopeValues = ['frame0', 'frame1', 'frame2']
+  const stopPropagationSpy = jest.fn()
+  const mockEvent = { preventDefault: preventDefaultSpy, stopPropagation: stopPropagationSpy }
+
+  let button
+  let wrapper
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useState')

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/ThumbnailBorder.spec.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/ThumbnailBorder.spec.js
@@ -3,9 +3,9 @@ import React from 'react'
 import { Text } from 'grommet'
 import ThumbnailBorder, { StyledBox } from './ThumbnailBorder'
 
-let wrapper
-
 describe('Component > FilmstripViewer', function () {
+  let wrapper
+
   beforeEach(function() {
     wrapper = shallow(<ThumbnailBorder />)
   })

--- a/src/components/LineViewer/LineViewer.spec.js
+++ b/src/components/LineViewer/LineViewer.spec.js
@@ -4,42 +4,42 @@ import { Button, CheckBox, Text, TextInput } from 'grommet'
 import DeleteModal from './components/DeleteModal'
 import { LineViewer } from './LineViewer'
 
-const setConsensusTextSpy = jest.fn()
-const setInputTextSpy = jest.fn()
-const setItemSpy = jest.fn()
-const transcriptionOptions = [
-  {
-    date: '',
-    goldStandard: false,
-    user: 'A_User',
-    text: 'Testing'
-  }
-]
-const reduction = {
-  consensus_score: 0,
-  consensus_text: 'Consensus Text',
-  number_views: 0,
-  setConsensusText: setConsensusTextSpy
-}
-
-jest
-  .spyOn(React, 'useRef')
-  .mockImplementation(() => { return { current: { value: 'Input Field' } }})
-
-let wrapper = shallow(
-  <LineViewer
-    algorithmChoice={transcriptionOptions.length}
-    consensusText='Original Consensus Text'
-    inputText='Input Field'
-    reduction={reduction}
-    setInputText={setInputTextSpy}
-    setItem={setItemSpy}
-    transcriptionOptions={transcriptionOptions}
-    typedChoice={transcriptionOptions.length + 1}
-  />
-)
-
 describe('Component > LineViewer', function () {
+  const setConsensusTextSpy = jest.fn()
+  const setInputTextSpy = jest.fn()
+  const setItemSpy = jest.fn()
+  const transcriptionOptions = [
+    {
+      date: '',
+      goldStandard: false,
+      user: 'A_User',
+      text: 'Testing'
+    }
+  ]
+  const reduction = {
+    consensus_score: 0,
+    consensus_text: 'Consensus Text',
+    number_views: 0,
+    setConsensusText: setConsensusTextSpy
+  }
+
+  jest
+    .spyOn(React, 'useRef')
+    .mockImplementation(() => { return { current: { value: 'Input Field' } }})
+
+  let wrapper = shallow(
+    <LineViewer
+      algorithmChoice={transcriptionOptions.length}
+      consensusText='Original Consensus Text'
+      inputText='Input Field'
+      reduction={reduction}
+      setInputText={setInputTextSpy}
+      setItem={setItemSpy}
+      transcriptionOptions={transcriptionOptions}
+      typedChoice={transcriptionOptions.length + 1}
+    />
+  )
+
   afterEach(() => jest.clearAllMocks());
 
   it('should render without crashing', function () {

--- a/src/components/LineViewer/components/DeleteModal/DeleteModal.spec.js
+++ b/src/components/LineViewer/components/DeleteModal/DeleteModal.spec.js
@@ -3,11 +3,11 @@ import React from 'react'
 import { Button } from 'grommet'
 import DeleteModal from './DeleteModal'
 
-let wrapper
-const deleteLineSpy = jest.fn()
-const toggleModalSpy = jest.fn()
-
 describe('Component > DeleteModal', function () {
+  let wrapper
+  const deleteLineSpy = jest.fn()
+  const toggleModalSpy = jest.fn()
+
   beforeEach(function () {
     wrapper = shallow(
       <DeleteModal

--- a/src/components/LineViewer/components/DeleteModal/DeleteModalContainer.spec.js
+++ b/src/components/LineViewer/components/DeleteModal/DeleteModalContainer.spec.js
@@ -2,17 +2,17 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import DeleteModalContainer from './DeleteModalContainer'
 
-let wrapper
-const deleteCurrentLineSpy = jest.fn()
-const toggleModalSpy = jest.fn()
-
-const context = {
-  transcriptions: {
-    deleteCurrentLine: deleteCurrentLineSpy
-  }
-}
-
 describe('Component > DeleteModalContainer', function () {
+  let wrapper
+  const deleteCurrentLineSpy = jest.fn()
+  const toggleModalSpy = jest.fn()
+
+  const context = {
+    transcriptions: {
+      deleteCurrentLine: deleteCurrentLineSpy
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/LineViewer/components/FlagButtons/FlagButton.spec.js
+++ b/src/components/LineViewer/components/FlagButtons/FlagButton.spec.js
@@ -5,10 +5,10 @@ import renderer from 'react-test-renderer'
 import 'jest-styled-components'
 import FlagButton, { StyledButton, StyledFontAwesomeIcon } from './FlagButton'
 
-let wrapper
-const onShowFlagSpy = jest.fn()
-
 describe('Component > FlagButton', function () {
+  let wrapper
+  const onShowFlagSpy = jest.fn()
+
   beforeEach(function () {
     wrapper = shallow(<FlagButton onShowFlag={onShowFlagSpy} />)
   })

--- a/src/components/LineViewer/components/FlagButtons/FlagButtonContainer.spec.js
+++ b/src/components/LineViewer/components/FlagButtons/FlagButtonContainer.spec.js
@@ -2,13 +2,13 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import FlagButtonContainer from './FlagButtonContainer'
 
-let wrapper
-const toggleCurrentFlagSpy = jest.fn()
-const reduction = {
-  toggleCurrentFlag: toggleCurrentFlagSpy
-}
-
 describe('Component > FlagButtonContainer', function () {
+  let wrapper
+  const toggleCurrentFlagSpy = jest.fn()
+  const reduction = {
+    toggleCurrentFlag: toggleCurrentFlagSpy
+  }
+
   beforeEach(function() {
     wrapper = shallow(<FlagButtonContainer reduction={reduction} />);
   })

--- a/src/components/LineViewer/components/FlagButtons/SeenButtonContainer.spec.js
+++ b/src/components/LineViewer/components/FlagButtons/SeenButtonContainer.spec.js
@@ -2,13 +2,13 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import SeenButtonContainer from './SeenButtonContainer'
 
-let wrapper
-const toggleCurrentSeenSpy = jest.fn()
-const reduction = {
-  toggleCurrentSeen: toggleCurrentSeenSpy
-}
-
 describe('Component > SeenButtonContainer', function () {
+  let wrapper
+  const toggleCurrentSeenSpy = jest.fn()
+  const reduction = {
+    toggleCurrentSeen: toggleCurrentSeenSpy
+  }
+
   beforeEach(function() {
     wrapper = shallow(<SeenButtonContainer reduction={reduction} />);
   })

--- a/src/components/LineViewer/components/TranscriptionLine.spec.js
+++ b/src/components/LineViewer/components/TranscriptionLine.spec.js
@@ -5,13 +5,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faStar } from '@fortawesome/free-solid-svg-icons'
 import TranscriptionLine, { ItalicText } from './TranscriptionLine'
 
-let wrapper
-
-const gsTranscription = { goldStandard: true }
-const index = 0
-const setItemSpy = jest.fn()
-
 describe('Component > TranscriptionLine', function () {
+  let wrapper
+
+  const gsTranscription = { goldStandard: true }
+  const index = 0
+  const setItemSpy = jest.fn()
+
   beforeEach(function() {
     wrapper = shallow(
       <TranscriptionLine

--- a/src/components/Modals/DeletePageModal/DeletePageModal.spec.js
+++ b/src/components/Modals/DeletePageModal/DeletePageModal.spec.js
@@ -2,9 +2,9 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import DeletePageModal from './DeletePageModal'
 
-let wrapper
-
 describe('Component > DeletePageModal', function () {
+  let wrapper
+
   beforeEach(function () {
     wrapper = shallow(<DeletePageModal />);
   })

--- a/src/components/Modals/DeletePageModal/DeletePageModalContainer.spec.js
+++ b/src/components/Modals/DeletePageModal/DeletePageModalContainer.spec.js
@@ -2,19 +2,19 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import DeletePageModalContainer from './DeletePageModalContainer'
 
-let wrapper
-const deletePageSpy = jest.fn()
-const toggleModalSpy = jest.fn()
-const contextValues = {
-  modal: {
-    toggleModal: toggleModalSpy
-  },
-  transcriptions: {
-    deletePage: deletePageSpy
-  }
-}
-
 describe('Component > DeletePageModalContainer', function () {
+  let wrapper
+  const deletePageSpy = jest.fn()
+  const toggleModalSpy = jest.fn()
+  const contextValues = {
+    modal: {
+      toggleModal: toggleModalSpy
+    },
+    transcriptions: {
+      deletePage: deletePageSpy
+    }
+  }
+
   beforeEach(function () {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/Modals/DownloadDataModal/DownloadDataModal.spec.js
+++ b/src/components/Modals/DownloadDataModal/DownloadDataModal.spec.js
@@ -4,10 +4,10 @@ import { Button, Text } from 'grommet'
 
 import DownloadDataModal from './DownloadDataModal'
 
-let wrapper
-const onCloseSpy = jest.fn()
-
 describe('Component > DownloadDataModal', function () {
+  let wrapper
+  const onCloseSpy = jest.fn()
+
   beforeEach(function () {
     wrapper = shallow(<DownloadDataModal onClose={onCloseSpy} />);
   })

--- a/src/components/Modals/DownloadDataModal/DownloadDataModalContainer.spec.js
+++ b/src/components/Modals/DownloadDataModal/DownloadDataModalContainer.spec.js
@@ -2,23 +2,23 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import DownloadDataModalContainer from './DownloadDataModalContainer'
 
-let wrapper
-const downloadDataSpy = jest.fn()
-const toggleModalSpy = jest.fn()
-const contextValues = {
-  client: {
-    downloadData: downloadDataSpy
-  },
-  modal: {
-    toggleModal: toggleModalSpy
-  },
-  transcriptions: {
-    approvedCount: 0,
-    all: new Map()
-  }
-}
-
 describe('Component > DownloadDataModalContainer', function () {
+  let wrapper
+  const downloadDataSpy = jest.fn()
+  const toggleModalSpy = jest.fn()
+  const contextValues = {
+    client: {
+      downloadData: downloadDataSpy
+    },
+    modal: {
+      toggleModal: toggleModalSpy
+    },
+    transcriptions: {
+      approvedCount: 0,
+      all: new Map()
+    }
+  }
+
   beforeEach(function () {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/Modals/LoadingModal/Loading.spec.js
+++ b/src/components/Modals/LoadingModal/Loading.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import Loading from './Loading'
 
-let wrapper
-
 describe('Component > Loading', function () {
+  let wrapper
+
   it('should render without crashing', function () {
     wrapper = shallow(<Loading />);
     expect(wrapper).toBeDefined()

--- a/src/components/Modals/SubjectLockedModal/SubjectLockedModal.spec.js
+++ b/src/components/Modals/SubjectLockedModal/SubjectLockedModal.spec.js
@@ -3,10 +3,10 @@ import React from 'react'
 import { Button } from 'grommet'
 import SubjectLockedModal from './SubjectLockedModal'
 
-let wrapper
-let onBackSpy = jest.fn()
-
 describe('Component > SubjectLockedModal', function () {
+  let wrapper
+  let onBackSpy = jest.fn()
+
   beforeAll(function () {
     wrapper = shallow(<SubjectLockedModal onBack={onBackSpy} />);
   })

--- a/src/components/Modals/SubjectLockedModal/SubjectLockedModalContainer.spec.js
+++ b/src/components/Modals/SubjectLockedModal/SubjectLockedModalContainer.spec.js
@@ -2,25 +2,25 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import { SubjectLockedModalContainer } from './SubjectLockedModalContainer'
 
-let wrapper
-const toggleModalSpy = jest.fn()
-const pushSpy = jest.fn()
-let history = {
-  location: {
-    pathname: '/projects/123/workflows/123/groups/123/subjects/123/edit'
-  },
-  push: pushSpy
-}
-const contextValues = {
-  modal: {
-    toggleModal: toggleModalSpy,
-  },
-  transcriptions: {
-    current: { locked_by: 'A_USER' }
-  }
-}
-
 describe('Component > SubjectLockedModalContainer', function () {
+  let wrapper
+  const toggleModalSpy = jest.fn()
+  const pushSpy = jest.fn()
+  let history = {
+    location: {
+      pathname: '/projects/123/workflows/123/groups/123/subjects/123/edit'
+    },
+    push: pushSpy
+  }
+  const contextValues = {
+    modal: {
+      toggleModal: toggleModalSpy,
+    },
+    transcriptions: {
+      current: { locked_by: 'A_USER' }
+    }
+  }
+
   beforeAll(function () {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/Modals/UnapproveModal/UnapproveModal.spec.js
+++ b/src/components/Modals/UnapproveModal/UnapproveModal.spec.js
@@ -3,11 +3,11 @@ import React from 'react'
 import { Button } from 'grommet'
 import UnapproveModal from './UnapproveModal'
 
-let wrapper
-let onCloseSpy = jest.fn()
-let onUnapproveSpy = jest.fn()
-
 describe('Component > UnapproveModal', function () {
+  let wrapper
+  let onCloseSpy = jest.fn()
+  let onUnapproveSpy = jest.fn()
+
   beforeAll(function () {
     wrapper = shallow(<UnapproveModal onClose={onCloseSpy} onUnapprove={onUnapproveSpy} />);
   })

--- a/src/components/Modals/UnapproveModal/UnapproveModalContainer.spec.js
+++ b/src/components/Modals/UnapproveModal/UnapproveModalContainer.spec.js
@@ -2,22 +2,22 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import UnapproveModalContainer from './UnapproveModalContainer'
 
-let wrapper
-let toggleModalSpy = jest.fn()
-let updateApprovalSpy = jest.fn()
-const contextValues = {
-  modal: {
-    toggleModal: toggleModalSpy,
-  },
-  projects: {
-    role: 'Researcher'
-  },
-  transcriptions: {
-    updateApproval: updateApprovalSpy
-  }
-}
-
 describe('Component > UnapproveModalContainer', function () {
+  let wrapper
+  let toggleModalSpy = jest.fn()
+  let updateApprovalSpy = jest.fn()
+  const contextValues = {
+    modal: {
+      toggleModal: toggleModalSpy,
+    },
+    projects: {
+      role: 'Researcher'
+    },
+    transcriptions: {
+      updateApproval: updateApprovalSpy
+    }
+  }
+
   beforeAll(function () {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/Overlay.spec.js
+++ b/src/components/Overlay.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import Overlay from './Overlay'
 
-let wrapper
-
 describe('Component > Overlay', function () {
+  let wrapper
+
   beforeEach(function() {
     wrapper = shallow(<Overlay />);
   })

--- a/src/components/ResourcesTable/ResourcesTable.spec.js
+++ b/src/components/ResourcesTable/ResourcesTable.spec.js
@@ -5,41 +5,41 @@ import ASYNC_STATES from 'helpers/asyncStates'
 import { ResourcesTable, StyledDataTable } from './ResourcesTable'
 import SearchTags from './components/SearchTags'
 
-let wrapper;
-let html;
-const onSelectionSpy = jest.fn()
-const pushSpy = jest.fn()
-
-const history = {
-  location: { pathname: '/projects' },
-  push: pushSpy
-}
-
-const COLUMNS = [
-  {
-    property: "firstColumn",
-    header: "First Column"
-  },
-  {
-    property: "secondColumn",
-    header: "Second Column",
-  },
-]
-
-const DATA = [
-  {
-    id: '1',
-    firstColumn: "First Item",
-    secondColumn: "Second Item"
-  },
-  {
-    id: '2',
-    firstColumn: "First Item",
-    secondColumn: "Second Item"
-  }
-]
-
 describe('Component > ResourcesTable', function () {
+  let wrapper;
+  let html;
+  const onSelectionSpy = jest.fn()
+  const pushSpy = jest.fn()
+
+  const history = {
+    location: { pathname: '/projects' },
+    push: pushSpy
+  }
+
+  const COLUMNS = [
+    {
+      property: "firstColumn",
+      header: "First Column"
+    },
+    {
+      property: "secondColumn",
+      header: "Second Column",
+    },
+  ]
+
+  const DATA = [
+    {
+      id: '1',
+      firstColumn: "First Item",
+      secondColumn: "Second Item"
+    },
+    {
+      id: '2',
+      firstColumn: "First Item",
+      secondColumn: "Second Item"
+    }
+  ]
+
   beforeEach(function() {
     wrapper = shallow(<ResourcesTable columns={COLUMNS} data={DATA} />)
     html = wrapper.html()

--- a/src/components/ResourcesTable/ResourcesTable.spec.js
+++ b/src/components/ResourcesTable/ResourcesTable.spec.js
@@ -68,6 +68,40 @@ describe('Component > ResourcesTable', function () {
 })
 
 describe('ResourcesTable functions', function () {
+  let wrapper;
+  let html;
+  const onSelectionSpy = jest.fn()
+  const pushSpy = jest.fn()
+
+  const history = {
+    location: { pathname: '/projects' },
+    push: pushSpy
+  }
+
+  const COLUMNS = [
+    {
+      property: "firstColumn",
+      header: "First Column"
+    },
+    {
+      property: "secondColumn",
+      header: "Second Column",
+    },
+  ]
+
+  const DATA = [
+    {
+      id: '1',
+      firstColumn: "First Item",
+      secondColumn: "Second Item"
+    },
+    {
+      id: '2',
+      firstColumn: "First Item",
+      secondColumn: "Second Item"
+    }
+  ]
+
   beforeEach(function () {
     wrapper = shallow(<ResourcesTable columns={COLUMNS} data={DATA} history={history} />)
   })
@@ -84,6 +118,40 @@ describe('ResourcesTable functions', function () {
 })
 
 describe('ResourcesTable onSelection prop', function () {
+  let wrapper;
+  let html;
+  const onSelectionSpy = jest.fn()
+  const pushSpy = jest.fn()
+
+  const history = {
+    location: { pathname: '/projects' },
+    push: pushSpy
+  }
+
+  const COLUMNS = [
+    {
+      property: "firstColumn",
+      header: "First Column"
+    },
+    {
+      property: "secondColumn",
+      header: "Second Column",
+    },
+  ]
+
+  const DATA = [
+    {
+      id: '1',
+      firstColumn: "First Item",
+      secondColumn: "Second Item"
+    },
+    {
+      id: '2',
+      firstColumn: "First Item",
+      secondColumn: "Second Item"
+    }
+  ]
+
   beforeEach(function () {
     wrapper = shallow(<ResourcesTable columns={COLUMNS} data={DATA} onSelection={onSelectionSpy} />)
   })

--- a/src/components/ResourcesTable/ResourcesTableContainer.spec.js
+++ b/src/components/ResourcesTable/ResourcesTableContainer.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import ResourcesTableContainer from './ResourcesTableContainer'
 
-let wrapper
-
 describe('Component > ResourcesTableContainer', function () {
+  let wrapper
+
   beforeEach(function() {
     wrapper = shallow(<ResourcesTableContainer />);
   })

--- a/src/components/ResourcesTable/components/SearchTags/SearchTag.spec.js
+++ b/src/components/ResourcesTable/components/SearchTags/SearchTag.spec.js
@@ -3,10 +3,10 @@ import React from 'react'
 import { Button } from 'grommet'
 import SearchTag from './SearchTag'
 
-let wrapper
-const clearTagSpy = jest.fn()
-
 describe('Component > SearchTag', function () {
+  let wrapper
+  const clearTagSpy = jest.fn()
+
   beforeEach(function() {
     wrapper = shallow(<SearchTag clearTag={clearTagSpy} />);
   })

--- a/src/components/ResourcesTable/components/SearchTags/SearchTagContainer.spec.js
+++ b/src/components/ResourcesTable/components/SearchTags/SearchTagContainer.spec.js
@@ -2,16 +2,16 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import SearchTagContainer from './SearchTagContainer'
 
-let wrapper
-const contextValues = {
-  search: {
-    approved: true,
-    id: '1',
-    type: 'ZOONIVERSE ID'
-  }
-}
-
 describe('Component > SearchTagContainer', function () {
+  let wrapper
+  const contextValues = {
+    search: {
+      approved: true,
+      id: '1',
+      type: 'ZOONIVERSE ID'
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/SearchModal/SearchModal.spec.js
+++ b/src/components/SearchModal/SearchModal.spec.js
@@ -4,23 +4,23 @@ import { Select } from 'grommet'
 import { Formik } from 'formik'
 import { SearchModal } from './SearchModal'
 
-let wrapper;
-let innerForm;
-let onSubmitSpy = jest.fn()
-let setFieldValueSpy = jest.fn()
-let setValueSpy = jest.fn()
-const initialValues = {
-  id: null,
-  type: '',
-  unseen: false,
-  in_progress: false,
-  ready: false,
-  approved: false,
-  flagged: false,
-  lowConsensus: false,
-}
-
 describe('Component > SearchModal', function () {
+  let wrapper;
+  let innerForm;
+  let onSubmitSpy = jest.fn()
+  let setFieldValueSpy = jest.fn()
+  let setValueSpy = jest.fn()
+  const initialValues = {
+    id: null,
+    type: '',
+    unseen: false,
+    in_progress: false,
+    ready: false,
+    approved: false,
+    flagged: false,
+    lowConsensus: false,
+  }
+
   beforeEach(function() {
     wrapper = shallow(
       <SearchModal

--- a/src/components/SearchModal/SearchModalContainer.spec.js
+++ b/src/components/SearchModal/SearchModalContainer.spec.js
@@ -2,19 +2,19 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import SearchModalContainer from './SearchModalContainer'
 
-let wrapper;
-const searchTranscriptionsSpy = jest.fn()
-const toggleModalSpy = jest.fn()
-const contextValues = {
-  modal: {
-    toggleModal: toggleModalSpy
-  },
-  search: {
-    searchTranscriptions: searchTranscriptionsSpy
-  }
-}
-
 describe('Component > SearchModalContainer', function () {
+  let wrapper;
+  const searchTranscriptionsSpy = jest.fn()
+  const toggleModalSpy = jest.fn()
+  const contextValues = {
+    modal: {
+      toggleModal: toggleModalSpy
+    },
+    search: {
+      searchTranscriptions: searchTranscriptionsSpy
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/SearchModal/components/SearchCheckBox.spec.js
+++ b/src/components/SearchModal/components/SearchCheckBox.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import { SearchCheckBox } from './SearchCheckBox'
 
-let wrapper;
-
 describe('Component > SearchCheckBox', function () {
+  let wrapper;
+
   beforeEach(function() {
     wrapper = shallow(<SearchCheckBox />);
   })

--- a/src/components/StepNavigation/StepNavigation.spec.js
+++ b/src/components/StepNavigation/StepNavigation.spec.js
@@ -3,12 +3,12 @@ import React from 'react'
 import { Button, RadioButton, RadioButtonGroup, Text } from 'grommet'
 import StepNavigation from './StepNavigation'
 
-let wrapper
-const setStepSpy = jest.fn()
-const steps = [0, 1, 2, 3, 4, 5, 6]
-const TOTAL_PAGES = 7
-
 describe('Component > StepNavigation', function () {
+  let wrapper
+  const setStepSpy = jest.fn()
+  const steps = [0, 1, 2, 3, 4, 5, 6]
+  const TOTAL_PAGES = 7
+
   beforeEach(function() {
     wrapper = shallow(
       <StepNavigation

--- a/src/components/StepNavigation/StepNavigation.spec.js
+++ b/src/components/StepNavigation/StepNavigation.spec.js
@@ -76,6 +76,8 @@ describe('Component > StepNavigation', function () {
 })
 
 describe('StepNavigation with no props', function () {
+  let wrapper
+
   it('should return nothing', function () {
     wrapper = shallow(<StepNavigation />)
     expect(wrapper.props()).toEqual({})

--- a/src/components/SubjectViewer/SubjectViewerContainer.spec.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.spec.js
@@ -5,26 +5,26 @@ import SubjectViewerContainer from './SubjectViewerContainer'
 import SVGView from './components/SVGView'
 import ImageTools from './components/ImageTools'
 
-let wrapper
-const testContext = {
-  aggregations: {
-    showModal: false
-  },
-  subjects: {
-    current: {
-      locations: [{ image: 'www.fakelocation.com' }]
-    },
-    index: 0
-  },
-  image: {
-    rotation: 0,
-    scale: 1,
-    translateX: 0,
-    translateY: 0
-  }
-}
-
 describe('Component > SubjectViewerContainer', function () {
+  let wrapper
+  const testContext = {
+    aggregations: {
+      showModal: false
+    },
+    subjects: {
+      current: {
+        locations: [{ image: 'www.fakelocation.com' }]
+      },
+      index: 0
+    },
+    image: {
+      rotation: 0,
+      scale: 1,
+      translateX: 0,
+      translateY: 0
+    }
+  }
+
   beforeEach(function() {
     wrapper = shallow(<SubjectViewerContainer />);
   })

--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPane.spec.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPane.spec.js
@@ -3,15 +3,15 @@ import React from 'react'
 import AnnotationsPane from './AnnotationsPane'
 import SVGLines from './SVGLines'
 
-let wrapper
-
-const lines = [
-  { x1: 0, x2: 0, y1: 10, y2: 10 },
-  { x1: 0, x2: 0, y1: 0, y2: 10 }
-]
-const onLineClickSpy = jest.fn()
-
 describe('Component > AnnotationsPane', function () {
+  let wrapper
+
+  const lines = [
+    { x1: 0, x2: 0, y1: 10, y2: 10 },
+    { x1: 0, x2: 0, y1: 0, y2: 10 }
+  ]
+  const onLineClickSpy = jest.fn()
+
   beforeEach(function() {
     wrapper = shallow(
       <AnnotationsPane

--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.spec.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.spec.js
@@ -2,28 +2,28 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import AnnotationsPaneContainer from './AnnotationsPaneContainer'
 
-let wrapper
-
-const extract = {
-  data: { frame0: {} }
-}
-const contextValues = {
-  editor: {
-    linesVisible: true
-  },
-  transcriptions: {
-    activeSlope: 0,
-    approved: false,
-    currentTranscriptions: [{
-      clusters_x: [],
-      clusters_y: []
-    }],
-    index: 0,
-    extracts: [extract]
-  }
-}
-
 describe('Component > AnnotationsPaneContainer', function () {
+  let wrapper
+
+  const extract = {
+    data: { frame0: {} }
+  }
+  const contextValues = {
+    editor: {
+      linesVisible: true
+    },
+    transcriptions: {
+      activeSlope: 0,
+      approved: false,
+      currentTranscriptions: [{
+        clusters_x: [],
+        clusters_y: []
+      }],
+      index: 0,
+      extracts: [extract]
+    }
+  }
+
   it('should render with transcriptions', function () {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.spec.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.spec.js
@@ -4,20 +4,20 @@ import renderer from 'react-test-renderer'
 import 'jest-styled-components'
 import SVGLines, { G } from './SVGLines'
 
-let wrapper
-
-const lines = [
-  { x1: 0, x2: 0, y1: 100, y2: 100, slope: 0 },
-  { x1: 0, x2: 0, y1: 200, y2: 200, slope: 0 },
-  { x1: 0, x2: 0, y1: 300, y2: 300, slope: 90 },
-  { x1: 0, x2: 0, y1: 400, y2: 400, slope: 90 }
-]
-
-const rightToLeftLines = [
-  { x1: 0, x2: 100, y1: 100, y2: 100, slope: 0 }
-]
-
 describe('Component > SVGLines', function () {
+  let wrapper
+
+  const lines = [
+    { x1: 0, x2: 0, y1: 100, y2: 100, slope: 0 },
+    { x1: 0, x2: 0, y1: 200, y2: 200, slope: 0 },
+    { x1: 0, x2: 0, y1: 300, y2: 300, slope: 90 },
+    { x1: 0, x2: 0, y1: 400, y2: 400, slope: 90 }
+  ]
+
+  const rightToLeftLines = [
+    { x1: 0, x2: 100, y1: 100, y2: 100, slope: 0 }
+  ]
+
   beforeEach(function() {
     wrapper = shallow(<SVGLines activeSlope={90} lines={lines} />);
   })

--- a/src/components/SubjectViewer/components/ImageTools/ImageTools.spec.js
+++ b/src/components/SubjectViewer/components/ImageTools/ImageTools.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import ImageTools from './ImageTools'
 
-let wrapper
-
 describe('Component > ImageTools', function () {
+  let wrapper
+
   beforeEach(function() {
     wrapper = shallow(<ImageTools />);
   })

--- a/src/components/SubjectViewer/components/SVGView/SVGView.spec.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGView.spec.js
@@ -3,20 +3,20 @@ import React from 'react'
 import SVGView from './SVGView'
 import 'jest-styled-components'
 
-const ref = React.createRef()
-ref.current = { getBoundingClientRect: () => {
-  return {
-    height: 100,
-    width: 100
-  }
-} }
-
-const setTranslateSpy = jest.fn()
-const mockEvent = {
-  preventDefault: () => {}
-}
-
 describe('Component > SVGView', function () {
+  const ref = React.createRef()
+  ref.current = { getBoundingClientRect: () => {
+    return {
+      height: 100,
+      width: 100
+    }
+  } }
+
+  const setTranslateSpy = jest.fn()
+  const mockEvent = {
+    preventDefault: () => {}
+  }
+
   afterEach(() => jest.clearAllMocks());
 
   describe('when disabled', function () {

--- a/src/components/SubjectViewer/components/SVGView/SVGViewContainer.spec.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGViewContainer.spec.js
@@ -5,47 +5,47 @@ import ASYNC_STATES from 'helpers/asyncStates'
 import SVGViewContainer from './SVGViewContainer'
 import SVGView from './SVGView'
 
-let svg
-let wrapper
-const setScaleSpy = jest.fn()
-const setStateSpy = jest.fn()
-
-const contextValues = {
-  editor: {
-    linesVisible: true
-  },
-  image: {
-    rotation: 0,
-    scale: 1,
-    setScale: setScaleSpy,
-    translateX: 0,
-    translateY: 0
-  },
-  subjects: {
-    asyncState: ASYNC_STATES.READY,
-    current: {
-      locations: [{
-        image: 'www.test.com'
-    }]
-    },
-  },
-  transcriptions: {
-    current: null,
-    extracts: [],
-    index: 0
-  }
-}
-
-class ValidImage {
-  constructor () {
-    this.naturalHeight = 200
-    this.naturalWidth = 100
-  }
-}
-
-const image = new ValidImage()
-
 describe('Component > SVGViewContainer', function () {
+  let svg
+  let wrapper
+  const setScaleSpy = jest.fn()
+  const setStateSpy = jest.fn()
+
+  const contextValues = {
+    editor: {
+      linesVisible: true
+    },
+    image: {
+      rotation: 0,
+      scale: 1,
+      setScale: setScaleSpy,
+      translateX: 0,
+      translateY: 0
+    },
+    subjects: {
+      asyncState: ASYNC_STATES.READY,
+      current: {
+        locations: [{
+          image: 'www.test.com'
+      }]
+      },
+    },
+    transcriptions: {
+      current: null,
+      extracts: [],
+      index: 0
+    }
+  }
+
+  class ValidImage {
+    constructor () {
+      this.naturalHeight = 200
+      this.naturalWidth = 100
+    }
+  }
+
+  const image = new ValidImage()
+
   beforeEach(async function () {
     jest
       .spyOn(React, 'useContext')

--- a/src/components/SubjectViewer/components/SubjectViewerHeader/SubjectViewerHeaderContainer.spec.js
+++ b/src/components/SubjectViewer/components/SubjectViewerHeader/SubjectViewerHeaderContainer.spec.js
@@ -2,19 +2,19 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import SubjectViewerHeaderContainer from './SubjectViewerHeaderContainer'
 
-let wrapper
-const toggleLineVisibilitySpy = jest.fn()
-const contextValues = {
-  editor: {
-    linesVisible: true,
-    toggleLineVisibility: toggleLineVisibilitySpy
-  },
-  transcriptions: {
-    isActive: false
-  }
-}
-
 describe('Component > SubjectViewerHeaderContainer', function () {
+  let wrapper
+  const toggleLineVisibilitySpy = jest.fn()
+  const contextValues = {
+    editor: {
+      linesVisible: true,
+      toggleLineVisibility: toggleLineVisibilitySpy
+    },
+    transcriptions: {
+      isActive: false
+    }
+  }
+
   beforeEach(function() {
     jest
       .spyOn(React, 'useContext')

--- a/src/helpers/gsCountFromExtracts.spec.js
+++ b/src/helpers/gsCountFromExtracts.spec.js
@@ -1,27 +1,27 @@
 import gsCountFromExtracts from './gsCountFromExtracts'
 
-const gsExtract = {
-  data: {
-    frame0: { gold_standard: true }
-  }
-}
-
-const extract = {
-  data: {
-    frame0: { gold_standard: false }
-  }
-}
-
-const gsExtracts = new Map()
-gsExtracts.set('one', gsExtract)
-gsExtracts.set('two', gsExtract)
-gsExtracts.set('three', extract)
-
-const extracts = new Map()
-extracts.set('one', extract)
-extracts.set('two', extract)
-
 describe('Helper > gsCountFromExtracts', function () {
+  const gsExtract = {
+    data: {
+      frame0: { gold_standard: true }
+    }
+  }
+
+  const extract = {
+    data: {
+      frame0: { gold_standard: false }
+    }
+  }
+
+  const gsExtracts = new Map()
+  gsExtracts.set('one', gsExtract)
+  gsExtracts.set('two', gsExtract)
+  gsExtracts.set('three', extract)
+
+  const extracts = new Map()
+  extracts.set('one', extract)
+  extracts.set('two', extract)
+
   it('should count the amount of Gold Standard extracts', function () {
     const result = gsCountFromExtracts(gsExtracts)
     expect(result).toBe(2)

--- a/src/helpers/indexToColor/indexToColor.spec.js
+++ b/src/helpers/indexToColor/indexToColor.spec.js
@@ -1,8 +1,8 @@
 import indexToColor from './indexToColor'
 
-let FINAL_CASE = 11
-
 describe('Helper > indexToColor', function () {
+  let FINAL_CASE = 11
+
   it('should return a black hex code by default', function () {
     const value = indexToColor()
     expect(value).toBe('#000000')

--- a/src/helpers/parseTranscriptionData.spec.js
+++ b/src/helpers/parseTranscriptionData.spec.js
@@ -1,88 +1,90 @@
 import { constructCoordinates, constructText, mapExtractsToReductions } from './parseTranscriptionData'
 
-const date = new Date()
+describe('Helpers > parseTranscriptionData', function () {
+  const date = new Date()
 
-const line = {
-  clusters_text: [
-    ['Hello', 'Hello', ''],
-    ['World', 'Worlde', 'Wurld']
-  ],
-  clusters_x: [0, 100],
-  clusters_y: [100, 200]
-}
-export const mockExtract = {
-  frame0: {
-    slope: [0],
-    text: [['My text for this line']],
-    points: {
-      x: [[200, 200]],
-      y: [[300, 300]]
-    }
-  },
-  time: date
-}
-const extractsByUser = {
-  1: [mockExtract]
-}
-export const mockReduction = {
-  gold_standard: [false],
-  line_slope: 0,
-  extract_index: [0],
-  user_ids: [1]
-}
-const reductionText = [['My text for this line']]
-
-describe('Helper > constructCoordinates', function () {
-  it('return an empty array if provided empty argument', function () {
-    const value = constructCoordinates()
-    expect(value.length).toBe(0)
-  })
-
-  it('should parse coordinates', function () {
-    const value = constructCoordinates(line)
-    const expectation = [
-      { x1: line.clusters_x[0],
-        x2: line.clusters_x[1],
-        y1: line.clusters_y[0],
-        y2: line.clusters_y[1]
+  const line = {
+    clusters_text: [
+      ['Hello', 'Hello', ''],
+      ['World', 'Worlde', 'Wurld']
+    ],
+    clusters_x: [0, 100],
+    clusters_y: [100, 200]
+  }
+  export const mockExtract = {
+    frame0: {
+      slope: [0],
+      text: [['My text for this line']],
+      points: {
+        x: [[200, 200]],
+        y: [[300, 300]]
       }
-    ]
-    expect(value).toEqual(expectation)
-  })
-})
+    },
+    time: date
+  }
+  const extractsByUser = {
+    1: [mockExtract]
+  }
+  export const mockReduction = {
+    gold_standard: [false],
+    line_slope: 0,
+    extract_index: [0],
+    user_ids: [1]
+  }
+  const reductionText = [['My text for this line']]
 
-describe('Helper > constructText', function () {
-  it('return an empty array if provided empty argument', function () {
-    const value = constructText()
-    expect(value.length).toBe(0)
-  })
+  describe('Helper > constructCoordinates', function () {
+    it('return an empty array if provided empty argument', function () {
+      const value = constructCoordinates()
+      expect(value.length).toBe(0)
+    })
 
-  it('should parse coordinates', function () {
-    const value = constructText(line)
-    const expectation = [ 'Hello World', 'Hello Worlde', 'Wurld' ]
-    expect(value).toEqual(expectation)
-  })
-})
-
-describe('Helper > mapExtractsToReductions', function () {
-  it('returns data needed for a line', function () {
-    const result = mapExtractsToReductions(extractsByUser, mockReduction, 0, reductionText, 0)
-    const time = new Date(0)
-    time.setUTCSeconds(date)
-    const expectation = {
-      goldStandard: false,
-      slope: 0,
-      text: 'My text for this line',
-      x1: 200,
-      x2: 200,
-      y1: 300,
-      y2: 300,
-      time }
-    expect(result).toEqual([expectation])
+    it('should parse coordinates', function () {
+      const value = constructCoordinates(line)
+      const expectation = [
+        { x1: line.clusters_x[0],
+          x2: line.clusters_x[1],
+          y1: line.clusters_y[0],
+          y2: line.clusters_y[1]
+        }
+      ]
+      expect(value).toEqual(expectation)
+    })
   })
 
-  it('should run with incomplete data', function () {
-    const result = mapExtractsToReductions()
-    expect(result).toEqual([])
+  describe('Helper > constructText', function () {
+    it('return an empty array if provided empty argument', function () {
+      const value = constructText()
+      expect(value.length).toBe(0)
+    })
+
+    it('should parse coordinates', function () {
+      const value = constructText(line)
+      const expectation = [ 'Hello World', 'Hello Worlde', 'Wurld' ]
+      expect(value).toEqual(expectation)
+    })
+  })
+
+  describe('Helper > mapExtractsToReductions', function () {
+    it('returns data needed for a line', function () {
+      const result = mapExtractsToReductions(extractsByUser, mockReduction, 0, reductionText, 0)
+      const time = new Date(0)
+      time.setUTCSeconds(date)
+      const expectation = {
+        goldStandard: false,
+        slope: 0,
+        text: 'My text for this line',
+        x1: 200,
+        x2: 200,
+        y1: 300,
+        y2: 300,
+        time }
+      expect(result).toEqual([expectation])
+    })
+
+    it('should run with incomplete data', function () {
+      const result = mapExtractsToReductions()
+      expect(result).toEqual([])
+    })
   })
 })

--- a/src/helpers/parseTranscriptionData.spec.js
+++ b/src/helpers/parseTranscriptionData.spec.js
@@ -11,7 +11,7 @@ describe('Helpers > parseTranscriptionData', function () {
     clusters_x: [0, 100],
     clusters_y: [100, 200]
   }
-  export const mockExtract = {
+  const mockExtract = {
     frame0: {
       slope: [0],
       text: [['My text for this line']],
@@ -25,7 +25,7 @@ describe('Helpers > parseTranscriptionData', function () {
   const extractsByUser = {
     1: [mockExtract]
   }
-  export const mockReduction = {
+  const mockReduction = {
     gold_standard: [false],
     line_slope: 0,
     extract_index: [0],

--- a/src/screens/About/About.spec.js
+++ b/src/screens/About/About.spec.js
@@ -2,14 +2,14 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import About from './About'
 
-let wrapper
-let setState = jest.fn()
-const modal = {
-  caption: 'This Image',
-  image: 'image.png'
-}
-
 describe('Component > About', function () {
+  let wrapper
+  let setState = jest.fn()
+  const modal = {
+    caption: 'This Image',
+    image: 'image.png'
+  }
+
   beforeEach(function () {
     jest
       .spyOn(React, 'useState')

--- a/src/screens/About/components/ContentsTable.spec.js
+++ b/src/screens/About/components/ContentsTable.spec.js
@@ -2,15 +2,15 @@ import { mount } from 'enzyme'
 import React from 'react'
 import ContentsTable from './ContentsTable'
 
-const ref = React.createRef()
-ref.current = { getBoundingClientRect: () => {
-  return {
-    height: 100,
-    width: 100
-  }
-} }
-
 describe('Component > ContentsTable', function () {
+  const ref = React.createRef()
+  ref.current = { getBoundingClientRect: () => {
+    return {
+      height: 100,
+      width: 100
+    }
+  } }
+
   describe('with a ref', function () {
     it('should render without crashing', function () {
       const wrapper = mount(

--- a/src/screens/About/components/PhotoBlock.spec.js
+++ b/src/screens/About/components/PhotoBlock.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import PhotoBlock, { CapitalText, StyledImage } from './PhotoBlock'
 
-let wrapper
-
 describe('Component > PhotoBlock', function () {
+  let wrapper
+
   beforeEach(function() {
     const photos = [{ alt: 'A photo' },{ alt: 'Another photo' }]
     wrapper = shallow(<PhotoBlock caption='A caption' photos={photos} />);

--- a/src/screens/Editor/Editor.spec.js
+++ b/src/screens/Editor/Editor.spec.js
@@ -6,75 +6,75 @@ import MODALS from 'helpers/modals'
 import { act } from 'react-dom/test-utils'
 import { Editor, Resizer } from './Editor'
 
-let wrapper
-const checkIfLockedSpy = jest.fn()
-const fetchSubjectSpy = jest.fn()
-const getResourcesSpy = jest.fn()
-const preventDefaultSpy = jest.fn()
-const resetImageSpy = jest.fn()
-const setActiveTranscriptionSpy = jest.fn()
-const setState = jest.fn()
-const toggleModalSpy = jest.fn()
-const unlockTranscriptionSpy = jest.fn()
-
-const match = {
-  params: {
-    subject: 2
-  }
-}
-const rect = {
-  top: 10,
-  left: 20
-}
-const refValue = {
-  current: {
-    clientHeight: 100,
-    clientWidth: 100,
-    getBoundingClientRect: () => rect
-  }
-}
-const mockEvent = {
-  clientX: 0,
-  clientY: 0,
-  preventDefault: preventDefaultSpy
-}
-const contextValues = {
-  aggregations: {
-    showModal: false
-  },
-  editor: {
-    layout: 'row'
-  },
-  getResources: getResourcesSpy,
-  image: {
-    reset: resetImageSpy,
-    zoomIn: () => {}
-  },
-  modal: {
-    toggleModal: toggleModalSpy
-  },
-  projects: {
-    isViewer: false
-  },
-  subjects: {
-    all: { '1': { locations: [{ 'image': 'site.com' }] } },
-    asyncState: ASYNC_STATES.IDLE,
-    current: { locations: [{ 'image': 'site.com' }] },
-    fetchSubject: fetchSubjectSpy,
-  },
-  transcriptions: {
-    checkIfLocked: checkIfLockedSpy,
-    current: undefined,
-    extracts: [],
-    index: 0,
-    lockedByCurrentUser: false,
-    setActiveTranscription: setActiveTranscriptionSpy,
-    slopeKeys: [],
-    unlockTranscription: unlockTranscriptionSpy
-  }
-}
-
 describe('Component > Editor', function () {
+  let wrapper
+  const checkIfLockedSpy = jest.fn()
+  const fetchSubjectSpy = jest.fn()
+  const getResourcesSpy = jest.fn()
+  const preventDefaultSpy = jest.fn()
+  const resetImageSpy = jest.fn()
+  const setActiveTranscriptionSpy = jest.fn()
+  const setState = jest.fn()
+  const toggleModalSpy = jest.fn()
+  const unlockTranscriptionSpy = jest.fn()
+
+  const match = {
+    params: {
+      subject: 2
+    }
+  }
+  const rect = {
+    top: 10,
+    left: 20
+  }
+  const refValue = {
+    current: {
+      clientHeight: 100,
+      clientWidth: 100,
+      getBoundingClientRect: () => rect
+    }
+  }
+  const mockEvent = {
+    clientX: 0,
+    clientY: 0,
+    preventDefault: preventDefaultSpy
+  }
+  const contextValues = {
+    aggregations: {
+      showModal: false
+    },
+    editor: {
+      layout: 'row'
+    },
+    getResources: getResourcesSpy,
+    image: {
+      reset: resetImageSpy,
+      zoomIn: () => {}
+    },
+    modal: {
+      toggleModal: toggleModalSpy
+    },
+    projects: {
+      isViewer: false
+    },
+    subjects: {
+      all: { '1': { locations: [{ 'image': 'site.com' }] } },
+      asyncState: ASYNC_STATES.IDLE,
+      current: { locations: [{ 'image': 'site.com' }] },
+      fetchSubject: fetchSubjectSpy,
+    },
+    transcriptions: {
+      checkIfLocked: checkIfLockedSpy,
+      current: undefined,
+      extracts: [],
+      index: 0,
+      lockedByCurrentUser: false,
+      setActiveTranscription: setActiveTranscriptionSpy,
+      slopeKeys: [],
+      unlockTranscription: unlockTranscriptionSpy
+    }
+  }
+
   it('should render without crashing', function () {
     wrapper = shallow(<Editor match={match} />);
     expect(wrapper).toBeDefined()

--- a/src/screens/GroupsIndex/GroupsPageContainer.spec.js
+++ b/src/screens/GroupsIndex/GroupsPageContainer.spec.js
@@ -3,29 +3,29 @@ import React from 'react'
 import ResourcesTable from '../../components/ResourcesTable'
 import { GroupsPageContainer } from './GroupsPageContainer'
 
-let wrapper
-const getResourcesSpy = jest.fn()
-const selectGroupSpy = jest.fn()
-const setPageSpy = jest.fn()
-const pushSpy = jest.fn()
-const contextValues = {
-  getResources: getResourcesSpy,
-  groups: {
-    all: [],
-    selectGroup: selectGroupSpy,
-    setPage: setPageSpy
-  }
-}
-const history = { push: pushSpy }
-const match = {
-  params: {
-    group: 1,
-    project: 1,
-    workflow: 1
-  }
-}
-
 describe('Component > GroupsPageContainer', function () {
+  let wrapper
+  const getResourcesSpy = jest.fn()
+  const selectGroupSpy = jest.fn()
+  const setPageSpy = jest.fn()
+  const pushSpy = jest.fn()
+  const contextValues = {
+    getResources: getResourcesSpy,
+    groups: {
+      all: [],
+      selectGroup: selectGroupSpy,
+      setPage: setPageSpy
+    }
+  }
+  const history = { push: pushSpy }
+  const match = {
+    params: {
+      group: 1,
+      project: 1,
+      workflow: 1
+    }
+  }
+
   beforeEach(function() {
     jest.spyOn(React, 'useContext')
       .mockImplementation(() => contextValues )

--- a/src/screens/Header/Header.spec.js
+++ b/src/screens/Header/Header.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import Header from './Header'
 
-let wrapper
-
 describe('Component > Header', function () {
+  let wrapper
+
   beforeEach(function() {
     wrapper = shallow(<Header />);
   })

--- a/src/screens/Header/components/ErrorNotifier.spec.js
+++ b/src/screens/Header/components/ErrorNotifier.spec.js
@@ -3,9 +3,9 @@ import React from 'react'
 import { Text } from 'grommet'
 import ErrorNotifier, { CapitalText } from './ErrorNotifier'
 
-let wrapper
-
 describe('Component > ErrorNotifier', function () {
+  let wrapper
+
   it('should show an error', function () {
     const error = { message: 'A Message', help: 'Some Help' }
     wrapper = shallow(

--- a/src/screens/Header/components/ErrorNotifierContainer.spec.js
+++ b/src/screens/Header/components/ErrorNotifierContainer.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import ErrorNotifierContainer from './ErrorNotifierContainer'
 
-let wrapper
-
 describe('Component > ErrorNotifierContainer', function () {
+  let wrapper
+
   beforeEach(function() {
     wrapper = shallow(<ErrorNotifierContainer />);
   })

--- a/src/screens/Home/Home.spec.js
+++ b/src/screens/Home/Home.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import Home from './Home'
 
-let wrapper
-
 describe('Component > Home', function () {
+  let wrapper
+
   beforeEach(function () {
     wrapper = shallow(<Home />)
   })

--- a/src/screens/Home/components/Footer/Footer.spec.js
+++ b/src/screens/Home/components/Footer/Footer.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import Footer from './Footer'
 
-let wrapper
-
 describe('Component > Footer', function () {
+  let wrapper
+
   beforeEach(function () {
     wrapper = shallow(<Footer />)
   })

--- a/src/screens/Home/components/InfoText.spec.js
+++ b/src/screens/Home/components/InfoText.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import InfoText from './InfoText'
 
-let wrapper
-
 describe('Component > InfoText', function () {
+  let wrapper
+
   beforeEach(function () {
     wrapper = shallow(<InfoText />)
   })

--- a/src/screens/Home/components/Label/Label.spec.js
+++ b/src/screens/Home/components/Label/Label.spec.js
@@ -2,9 +2,9 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import Label from './Label'
 
-let wrapper
-
 describe('Component > Label', function () {
+  let wrapper
+
   beforeEach(function () {
     wrapper = shallow(<Label />)
   })

--- a/src/screens/Home/components/LoginForm/LoginForm.spec.js
+++ b/src/screens/Home/components/LoginForm/LoginForm.spec.js
@@ -4,14 +4,14 @@ import { Formik } from 'formik'
 import { Button } from 'grommet'
 import LoginForm from './LoginForm'
 
-let wrapper
-let validateFormSpy = jest.fn().mockResolvedValue(true)
-const initialValues = {
-  login: '',
-  password: '',
-}
-
 describe('Component > LoginForm', function () {
+  let wrapper
+  let validateFormSpy = jest.fn().mockResolvedValue(true)
+  const initialValues = {
+    login: '',
+    password: '',
+  }
+
   beforeEach(function () {
     wrapper = shallow(<LoginForm />)
   })

--- a/src/screens/Home/components/LoginForm/LoginFormContainer.spec.js
+++ b/src/screens/Home/components/LoginForm/LoginFormContainer.spec.js
@@ -3,18 +3,18 @@ import React from 'react'
 import LoginFormContainer from './LoginFormContainer'
 import LoginForm from './LoginForm'
 
-let wrapper
-let loginForm
-let loginSpy = jest.fn()
-
-const contextValues = {
-  auth: {
-    error: 'Error!',
-    login: loginSpy,
-  }
-}
-
 describe('Component > LoginFormContainer', function () {
+  let wrapper
+  let loginForm
+  let loginSpy = jest.fn()
+
+  const contextValues = {
+    auth: {
+      error: 'Error!',
+      login: loginSpy,
+    }
+  }
+
   beforeEach(function () {
     jest
       .spyOn(React, 'useContext')

--- a/src/screens/ModalManager/ModalManager.spec.js
+++ b/src/screens/ModalManager/ModalManager.spec.js
@@ -4,14 +4,14 @@ import { Layer } from 'grommet'
 import MODALS from 'helpers/modals'
 import ModalManager from './ModalManager'
 
-let wrapper
-const contextValues = {
-  modal: {
-    current: MODALS.SEARCH,
-  }
-}
-
 describe('Component > ModalManager', function () {
+  let wrapper
+  const contextValues = {
+    modal: {
+      current: MODALS.SEARCH,
+    }
+  }
+
   beforeAll(function () {
     wrapper = shallow(<ModalManager />);
   })

--- a/src/screens/ProjectsIndex/ProjectsPageContainer.spec.js
+++ b/src/screens/ProjectsIndex/ProjectsPageContainer.spec.js
@@ -6,47 +6,47 @@ import { act } from 'react-dom/test-utils'
 import { ProjectPageContainer } from './ProjectsPageContainer'
 import ProjectCard from './components/ProjectCard'
 
-let wrapper
-const getResourcesSpy = jest.fn()
-const getProjectsSpy = jest.fn()
-const selectProjectSpy = jest.fn()
-
-const collabProjects = [
-  {
-    id: '1',
-    role: 'Volunteer',
-    avatar_src: 'www.image.com',
-    display_name: 'Fake Project'
-  }
-]
-const ownerProjects = [
-  {
-    id: '2',
-    role: 'Researcher',
-    avatar_src: 'www.image.com',
-    display_name: 'Fake Project'
-  }
-]
-const fakeUser = { id: 12 }
-const contextValues = {
-  auth: {
-    user: fakeUser
-  },
-  getResources: getResourcesSpy,
-  projects: {
-    asyncState: ASYNC_STATES.IDLE,
-    collabProjects,
-    getProjects: getProjectsSpy,
-    selectProject: selectProjectSpy,
-    ownerProjects
-  }
-}
-
-const match = {
-  params: {}
-}
-
 describe('Component > ProjectPageContainer', function () {
+  let wrapper
+  const getResourcesSpy = jest.fn()
+  const getProjectsSpy = jest.fn()
+  const selectProjectSpy = jest.fn()
+
+  const collabProjects = [
+    {
+      id: '1',
+      role: 'Volunteer',
+      avatar_src: 'www.image.com',
+      display_name: 'Fake Project'
+    }
+  ]
+  const ownerProjects = [
+    {
+      id: '2',
+      role: 'Researcher',
+      avatar_src: 'www.image.com',
+      display_name: 'Fake Project'
+    }
+  ]
+  const fakeUser = { id: 12 }
+  const contextValues = {
+    auth: {
+      user: fakeUser
+    },
+    getResources: getResourcesSpy,
+    projects: {
+      asyncState: ASYNC_STATES.IDLE,
+      collabProjects,
+      getProjects: getProjectsSpy,
+      selectProject: selectProjectSpy,
+      ownerProjects
+    }
+  }
+
+  const match = {
+    params: {}
+  }
+
   describe('with props', function () {
     beforeEach(function() {
       jest

--- a/src/screens/ProjectsIndex/components/ProjectCard/ProjectCard.spec.js
+++ b/src/screens/ProjectsIndex/components/ProjectCard/ProjectCard.spec.js
@@ -3,23 +3,23 @@ import React from 'react'
 import { Button, Image } from 'grommet'
 import { ProjectCard } from './ProjectCard'
 
-let wrapper
-const project = {
-  avatar_src: 'source.com'
-}
-const pushSpy = jest.fn()
-const setStateSpy = jest.fn()
-const history = {
-  push: pushSpy
-}
-const contextValues = {
-  workflows: {
-    setState: setStateSpy
-  }
-}
-
 
 describe('Component > ProjectCard', function () {
+  let wrapper
+  const project = {
+    avatar_src: 'source.com'
+  }
+  const pushSpy = jest.fn()
+  const setStateSpy = jest.fn()
+  const history = {
+    push: pushSpy
+  }
+  const contextValues = {
+    workflows: {
+      setState: setStateSpy
+    }
+  }
+
   beforeEach(function() {
     jest.spyOn(React, 'useContext')
       .mockImplementation((context) => contextValues)

--- a/src/screens/SubjectsIndex/HeaderButton.spec.js
+++ b/src/screens/SubjectsIndex/HeaderButton.spec.js
@@ -4,9 +4,9 @@ import { Button } from 'grommet'
 import { Down, Up } from 'grommet-icons'
 import HeaderButton from './HeaderButton'
 
-let wrapper
-
 describe('Component > HeaderButton', function () {
+  let wrapper
+
   beforeAll(function () {
     wrapper = shallow(<HeaderButton />);
   })

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.spec.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.spec.js
@@ -7,45 +7,45 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { SubjectsPageContainer } from './SubjectsPageContainer'
 import ResourcesTable from '../../components/ResourcesTable'
 
-let wrapper
-const getResourcesSpy = jest.fn()
-const fetchTranscriptionsSpy = jest.fn()
-const pushSpy = jest.fn()
-const resetSpy = jest.fn()
-const toggleModalSpy = jest.fn()
-const contextValues = {
-  auth: { userName: 'A_USER' },
-  getResources: getResourcesSpy,
-  modal: {
-    toggleModal: toggleModalSpy
-  },
-  search: {
-    active: false,
-    reset: resetSpy
-  },
-  transcriptions: {
-    all: { values: () => [] },
-    asyncState: ASYNC_STATES.IDLE,
-    fetchTranscriptions: fetchTranscriptionsSpy,
-    totalPages: 8
-  }
-}
-const history = {
-  location: {
-    pathname: '/projects/123/workflows/123/groups/123/subjects/123/edit'
-  },
-  push: pushSpy
-}
-const match = {
-  params: {
-    project: '123',
-    workflow: '123',
-    group: '123',
-    subject: '123'
-  }
-}
-
 describe('Component > SubjectsPageContainer', function () {
+  let wrapper
+  const getResourcesSpy = jest.fn()
+  const fetchTranscriptionsSpy = jest.fn()
+  const pushSpy = jest.fn()
+  const resetSpy = jest.fn()
+  const toggleModalSpy = jest.fn()
+  const contextValues = {
+    auth: { userName: 'A_USER' },
+    getResources: getResourcesSpy,
+    modal: {
+      toggleModal: toggleModalSpy
+    },
+    search: {
+      active: false,
+      reset: resetSpy
+    },
+    transcriptions: {
+      all: { values: () => [] },
+      asyncState: ASYNC_STATES.IDLE,
+      fetchTranscriptions: fetchTranscriptionsSpy,
+      totalPages: 8
+    }
+  }
+  const history = {
+    location: {
+      pathname: '/projects/123/workflows/123/groups/123/subjects/123/edit'
+    },
+    push: pushSpy
+  }
+  const match = {
+    params: {
+      project: '123',
+      workflow: '123',
+      group: '123',
+      subject: '123'
+    }
+  }
+
   describe('with idle state', function() {
     beforeEach(function() {
       jest.spyOn(React, 'useContext')

--- a/src/screens/WorkflowsIndex/WorkflowsPageContainer.spec.js
+++ b/src/screens/WorkflowsIndex/WorkflowsPageContainer.spec.js
@@ -6,35 +6,35 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import ResourcesTable from '../../components/ResourcesTable'
 import { WorkflowsPageContainer } from './WorkflowsPageContainer'
 
-let wrapper
-const fetchWorkflowsSpy = jest.fn()
-const pushSpy = jest.fn()
-const getResourcesSpy = jest.fn()
-const resetSpy = jest.fn()
-const selectWorkflowSpy = jest.fn()
-const contextValues = {
-  getResources: getResourcesSpy,
-  search: {
-    reset: resetSpy
-  },
-  workflows: {
-    all: [],
-    asyncState: ASYNC_STATES.IDLE,
-    error: 'THIS IS AN ERROR',
-    fetchWorkflows: fetchWorkflowsSpy,
-    selectWorkflow: selectWorkflowSpy
-  }
-}
-const history = {
-  push: pushSpy
-}
-const match = {
-  params: {
-    project: 1
-  }
-}
-
 describe('Component > WorkflowsPageContainer', function () {
+  let wrapper
+  const fetchWorkflowsSpy = jest.fn()
+  const pushSpy = jest.fn()
+  const getResourcesSpy = jest.fn()
+  const resetSpy = jest.fn()
+  const selectWorkflowSpy = jest.fn()
+  const contextValues = {
+    getResources: getResourcesSpy,
+    search: {
+      reset: resetSpy
+    },
+    workflows: {
+      all: [],
+      asyncState: ASYNC_STATES.IDLE,
+      error: 'THIS IS AN ERROR',
+      fetchWorkflows: fetchWorkflowsSpy,
+      selectWorkflow: selectWorkflowSpy
+    }
+  }
+  const history = {
+    push: pushSpy
+  }
+  const match = {
+    params: {
+      project: 1
+    }
+  }
+
   describe('idle state', function () {
     beforeEach(function() {
       jest.spyOn(React, 'useContext')

--- a/src/store/AggregationsStore.spec.js
+++ b/src/store/AggregationsStore.spec.js
@@ -1,8 +1,8 @@
 import { AggregationsStore } from './AggregationsStore'
 
-let aggregationsStore
-
 describe('AggregationsStore', function () {
+  let aggregationsStore
+
   beforeEach(function () {
     aggregationsStore = AggregationsStore.create()
   })

--- a/src/store/AppStore.spec.js
+++ b/src/store/AppStore.spec.js
@@ -1,24 +1,24 @@
 import { AppStore } from './AppStore'
 
-let appStore
-
-const params = {
-  project: '1',
-  workflow: '1',
-  group: '1',
-  subject: '1'
-}
-
-const checkCurrentSpy = jest.fn().mockResolvedValue(null)
-const initializeSpy = jest.fn()
-const selectProjectSpy = jest.fn().mockResolvedValue(null)
-const selectWorkflowSpy = jest.fn().mockResolvedValue(null)
-const selectGroupSpy = jest.fn()
-const selectTranscriptionSpy = jest.fn().mockResolvedValue(null)
-const selectGroupsSpy = jest.fn()
-const resetTransciptionsSpy = jest.fn()
-
 describe('AppStore', function () {
+  let appStore
+
+  const params = {
+    project: '1',
+    workflow: '1',
+    group: '1',
+    subject: '1'
+  }
+
+  const checkCurrentSpy = jest.fn().mockResolvedValue(null)
+  const initializeSpy = jest.fn()
+  const selectProjectSpy = jest.fn().mockResolvedValue(null)
+  const selectWorkflowSpy = jest.fn().mockResolvedValue(null)
+  const selectGroupSpy = jest.fn()
+  const selectTranscriptionSpy = jest.fn().mockResolvedValue(null)
+  const selectGroupsSpy = jest.fn()
+  const resetTransciptionsSpy = jest.fn()
+
   beforeAll(function() {
     appStore = AppStore.create()
     Object.defineProperty(

--- a/src/store/AuthStore.spec.js
+++ b/src/store/AuthStore.spec.js
@@ -2,17 +2,17 @@ import auth from 'panoptes-client/lib/auth'
 import { AppStore } from './AppStore'
 import history from '../history'
 
-const user = { id: '1', display_name: 'A_USER' }
-
-let authStore
-const setBearerTokenSpy = jest.fn()
-
-let rootStore = AppStore.create()
-Object.defineProperty(
-  rootStore.client, 'setBearerToken',
-  { writable: true, value: setBearerTokenSpy })
-
 describe('AuthStore', function () {
+  const user = { id: '1', display_name: 'A_USER' }
+
+  let authStore
+  const setBearerTokenSpy = jest.fn()
+
+  let rootStore = AppStore.create()
+  Object.defineProperty(
+    rootStore.client, 'setBearerToken',
+    { writable: true, value: setBearerTokenSpy })
+
   it('should exist', function () {
     authStore = rootStore.auth
     expect(authStore).toBeDefined()

--- a/src/store/ClientStore.spec.js
+++ b/src/store/ClientStore.spec.js
@@ -1,11 +1,11 @@
 import { AppStore } from './AppStore'
 
-let clientStore;
-let rootStore;
-let toveGetSpy = jest.fn().mockResolvedValue(new Response())
-const toveZipStub = { get: toveGetSpy }
-
 describe('ClientStore', function () {
+  let clientStore;
+  let rootStore;
+  let toveGetSpy = jest.fn().mockResolvedValue(new Response())
+  const toveZipStub = { get: toveGetSpy }
+
   beforeEach(function() {
     rootStore = AppStore.create({
       client: { toveZip: toveZipStub },

--- a/src/store/EditorStore.spec.js
+++ b/src/store/EditorStore.spec.js
@@ -1,8 +1,8 @@
 import { EditorStore } from './EditorStore'
 
-let editorStore
-
 describe('EditorStore', function () {
+  let editorStore
+
   beforeEach(function () {
     editorStore = EditorStore.create()
   })

--- a/src/store/GroupsStore.spec.js
+++ b/src/store/GroupsStore.spec.js
@@ -1,8 +1,8 @@
 import { GroupsStore } from './GroupsStore'
 
-let editorStore
-
 describe('GroupsStore', function () {
+  let editorStore
+
   beforeEach(function () {
     editorStore = GroupsStore.create()
   })

--- a/src/store/ImageStore.spec.js
+++ b/src/store/ImageStore.spec.js
@@ -6,16 +6,16 @@ import {
   MIN_STEP
 } from './ImageStore'
 
-let imageStore;
-
-const scaleValues = {
-  clientHeight: 200,
-  clientWidth: 100,
-  naturalHeight: 400,
-  naturalWidth: 200,
-}
-
 describe('Model > ImageStore', function () {
+  let imageStore;
+
+  const scaleValues = {
+    clientHeight: 200,
+    clientWidth: 100,
+    naturalHeight: 400,
+    naturalWidth: 200,
+  }
+
   beforeEach(function() {
     imageStore = ImageStore.create()
   })

--- a/src/store/ModalStore.spec.js
+++ b/src/store/ModalStore.spec.js
@@ -1,9 +1,9 @@
 import { ModalStore } from './ModalStore'
 import MODALS from 'helpers/modals'
 
-let modalStore
-
 describe('ModalStore', function () {
+  let modalStore
+
   beforeEach(function () {
     modalStore = ModalStore.create()
   })

--- a/src/store/ProjectsStore.spec.js
+++ b/src/store/ProjectsStore.spec.js
@@ -5,52 +5,52 @@ import mockJWT from 'helpers/mockJWT'
 import { AppStore } from './AppStore'
 import ProjectFactory from './factories/project'
 
-let projectsStore
-let ownedProject = ProjectFactory.build()
-let collabProject = ProjectFactory.build({ id: '2', display_name: 'Second Project' })
-let viewerProject = ProjectFactory.build({ id: '3', display_name: 'Third Project' })
-let error = { message: 'Failed to Return' }
-
-let ownerRole = {
-  links: {
-     project: '1'
-  },
-  roles: ['owner']
-}
-let collabRole = {
-  links: {
-     project: '2'
-  },
-  roles: ['expert']
-}
-let viewerRole = {
-  links: {
-     project: '3'
-  },
-  roles: ['tester']
-}
-let userRoles = [ownerRole, collabRole, viewerRole]
-
-let roles = { 1: 'Admin', 2: 'Editor', 3: 'Viewer' }
-let toveStub = {
-  get: () => Promise.resolve(
-    {
-      body: JSON.stringify(
-        {
-          data: [ownedProject, collabProject, viewerProject]
-        })
-    }
-  )
-}
-
-const rootStore = AppStore.create({
-  auth: {
-    user: { id: '1' }
-  },
-  client: { tove: mockJWT(toveStub), toveZip: mockJWT() }
-})
-
 describe('ProjectsStore', function () {
+  let projectsStore
+  let ownedProject = ProjectFactory.build()
+  let collabProject = ProjectFactory.build({ id: '2', display_name: 'Second Project' })
+  let viewerProject = ProjectFactory.build({ id: '3', display_name: 'Third Project' })
+  let error = { message: 'Failed to Return' }
+
+  let ownerRole = {
+    links: {
+       project: '1'
+    },
+    roles: ['owner']
+  }
+  let collabRole = {
+    links: {
+       project: '2'
+    },
+    roles: ['expert']
+  }
+  let viewerRole = {
+    links: {
+       project: '3'
+    },
+    roles: ['tester']
+  }
+  let userRoles = [ownerRole, collabRole, viewerRole]
+
+  let roles = { 1: 'Admin', 2: 'Editor', 3: 'Viewer' }
+  let toveStub = {
+    get: () => Promise.resolve(
+      {
+        body: JSON.stringify(
+          {
+            data: [ownedProject, collabProject, viewerProject]
+          })
+      }
+    )
+  }
+
+  const rootStore = AppStore.create({
+    auth: {
+      user: { id: '1' }
+    },
+    client: { tove: mockJWT(toveStub), toveZip: mockJWT() }
+  })
+
   beforeAll(function () {
     const clientSpy = jest.spyOn(apiClient, 'type')
     when(clientSpy).calledWith('projects')

--- a/src/store/ProjectsStore.spec.js
+++ b/src/store/ProjectsStore.spec.js
@@ -126,6 +126,68 @@ describe('ProjectsStore', function () {
 })
 
 describe('ProjectsStore getProject', function () {
+  let projectsStore
+  let ownedProject = ProjectFactory.build()
+  let collabProject = ProjectFactory.build({ id: '2', display_name: 'Second Project' })
+  let viewerProject = ProjectFactory.build({ id: '3', display_name: 'Third Project' })
+  let error = { message: 'Failed to Return' }
+
+  let ownerRole = {
+    links: {
+       project: '1'
+    },
+    roles: ['owner']
+  }
+  let collabRole = {
+    links: {
+       project: '2'
+    },
+    roles: ['expert']
+  }
+  let viewerRole = {
+    links: {
+       project: '3'
+    },
+    roles: ['tester']
+  }
+  let userRoles = [ownerRole, collabRole, viewerRole]
+
+  let roles = { 1: 'Admin', 2: 'Editor', 3: 'Viewer' }
+  let toveStub = {
+    get: () => Promise.resolve(
+      {
+        body: JSON.stringify(
+          {
+            data: [ownedProject, collabProject, viewerProject]
+          })
+      }
+    )
+  }
+
+  const rootStore = AppStore.create({
+    auth: {
+      user: { id: '1' }
+    },
+    client: { tove: mockJWT(toveStub), toveZip: mockJWT() }
+  })
+
+  beforeAll(function () {
+    const clientSpy = jest.spyOn(apiClient, 'type')
+    when(clientSpy).calledWith('projects')
+      .mockImplementation(() => {
+        return {
+          get: () => Promise.resolve([ownedProject, collabProject, viewerProject])
+        }
+      })
+    when(clientSpy).calledWith('project_roles')
+      .mockImplementation(() => {
+        return {
+          get: () => Promise.resolve([ownerRole, collabRole, viewerRole])
+        }
+      })
+    projectsStore = rootStore.projects
+  })
+
   it('returns undefined if no id passed', async function () {
     const returnValue = await projectsStore.getProject(null)
     expect(returnValue).toBe(undefined)
@@ -139,6 +201,51 @@ describe('ProjectsStore getProject', function () {
 })
 
 describe('ProjectsStore error states', function () {
+  let projectsStore
+  let ownedProject = ProjectFactory.build()
+  let collabProject = ProjectFactory.build({ id: '2', display_name: 'Second Project' })
+  let viewerProject = ProjectFactory.build({ id: '3', display_name: 'Third Project' })
+  let error = { message: 'Failed to Return' }
+
+  let ownerRole = {
+    links: {
+       project: '1'
+    },
+    roles: ['owner']
+  }
+  let collabRole = {
+    links: {
+       project: '2'
+    },
+    roles: ['expert']
+  }
+  let viewerRole = {
+    links: {
+       project: '3'
+    },
+    roles: ['tester']
+  }
+  let userRoles = [ownerRole, collabRole, viewerRole]
+
+  let roles = { 1: 'Admin', 2: 'Editor', 3: 'Viewer' }
+  let toveStub = {
+    get: () => Promise.resolve(
+      {
+        body: JSON.stringify(
+          {
+            data: [ownedProject, collabProject, viewerProject]
+          })
+      }
+    )
+  }
+
+  const rootStore = AppStore.create({
+    auth: {
+      user: { id: '1' }
+    },
+    client: { tove: mockJWT(toveStub), toveZip: mockJWT() }
+  })
+
   beforeAll(function() {
     jest
       .spyOn(apiClient, 'type')
@@ -165,6 +272,51 @@ describe('ProjectsStore error states', function () {
 })
 
 describe('ProjectsStore getRoles', function () {
+  let projectsStore
+  let ownedProject = ProjectFactory.build()
+  let collabProject = ProjectFactory.build({ id: '2', display_name: 'Second Project' })
+  let viewerProject = ProjectFactory.build({ id: '3', display_name: 'Third Project' })
+  let error = { message: 'Failed to Return' }
+
+  let ownerRole = {
+    links: {
+       project: '1'
+    },
+    roles: ['owner']
+  }
+  let collabRole = {
+    links: {
+       project: '2'
+    },
+    roles: ['expert']
+  }
+  let viewerRole = {
+    links: {
+       project: '3'
+    },
+    roles: ['tester']
+  }
+  let userRoles = [ownerRole, collabRole, viewerRole]
+
+  let roles = { 1: 'Admin', 2: 'Editor', 3: 'Viewer' }
+  let toveStub = {
+    get: () => Promise.resolve(
+      {
+        body: JSON.stringify(
+          {
+            data: [ownedProject, collabProject, viewerProject]
+          })
+      }
+    )
+  }
+
+  const rootStore = AppStore.create({
+    auth: {
+      user: { id: '1' }
+    },
+    client: { tove: mockJWT(toveStub), toveZip: mockJWT() }
+  })
+
   it('should set roles correctly', async function () {
     jest
       .spyOn(apiClient, 'type')
@@ -180,6 +332,51 @@ describe('ProjectsStore getRoles', function () {
 })
 
 describe('Default role', function () {
+  let projectsStore
+  let ownedProject = ProjectFactory.build()
+  let collabProject = ProjectFactory.build({ id: '2', display_name: 'Second Project' })
+  let viewerProject = ProjectFactory.build({ id: '3', display_name: 'Third Project' })
+  let error = { message: 'Failed to Return' }
+
+  let ownerRole = {
+    links: {
+       project: '1'
+    },
+    roles: ['owner']
+  }
+  let collabRole = {
+    links: {
+       project: '2'
+    },
+    roles: ['expert']
+  }
+  let viewerRole = {
+    links: {
+       project: '3'
+    },
+    roles: ['tester']
+  }
+  let userRoles = [ownerRole, collabRole, viewerRole]
+
+  let roles = { 1: 'Admin', 2: 'Editor', 3: 'Viewer' }
+  let toveStub = {
+    get: () => Promise.resolve(
+      {
+        body: JSON.stringify(
+          {
+            data: [ownedProject, collabProject, viewerProject]
+          })
+      }
+    )
+  }
+
+  const rootStore = AppStore.create({
+    auth: {
+      user: { id: '1' }
+    },
+    client: { tove: mockJWT(toveStub), toveZip: mockJWT() }
+  })
+
   it('should be viewer', async function () {
     const clientSpy = jest.spyOn(apiClient, 'type')
     when(clientSpy).calledWith('projects')

--- a/src/store/Reduction.spec.js
+++ b/src/store/Reduction.spec.js
@@ -1,20 +1,20 @@
 import Reduction from './Reduction'
 import * as mobX from 'mobx-state-tree'
 
-let reduction
-const checkForFlagUpdateSpy = jest.fn()
-const saveTranscriptionsSpy = jest.fn()
-
-const consensusText = 'Consensus Text'
-const contextValues = {
-  auth: { userName: 'User' },
-  transcriptions: {
-    checkForFlagUpdate: checkForFlagUpdateSpy,
-    saveTranscription: saveTranscriptionsSpy
-  }
-}
-
 describe('Reduction', function () {
+  let reduction
+  const checkForFlagUpdateSpy = jest.fn()
+  const saveTranscriptionsSpy = jest.fn()
+
+  const consensusText = 'Consensus Text'
+  const contextValues = {
+    auth: { userName: 'User' },
+    transcriptions: {
+      checkForFlagUpdate: checkForFlagUpdateSpy,
+      saveTranscription: saveTranscriptionsSpy
+    }
+  }
+
   beforeEach(function () {
     jest
       .spyOn(mobX, 'getRoot')

--- a/src/store/SearchStore.spec.js
+++ b/src/store/SearchStore.spec.js
@@ -1,10 +1,10 @@
 import { AppStore } from './AppStore'
 import STATUS from 'helpers/status'
 
-let searchStore
-const fetchTranscriptionsSpy = jest.fn()
-
 describe('SearchStore', function () {
+  let searchStore
+  const fetchTranscriptionsSpy = jest.fn()
+
   beforeEach(function () {
     const rootStore = AppStore.create()
     Object.defineProperty(

--- a/src/store/SubjectStore.spec.js
+++ b/src/store/SubjectStore.spec.js
@@ -3,15 +3,15 @@ import ASYNC_STATES from 'helpers/asyncStates'
 import { AppStore } from './AppStore'
 import { Subject } from './SubjectStore'
 
-let subjectStore
-
-const mockSubject = {
-  id: '1',
-  locations: [],
-  metadata: {}
-}
-
 describe('SubjectStore', function () {
+  let subjectStore
+
+  const mockSubject = {
+    id: '1',
+    locations: [],
+    metadata: {}
+  }
+
   beforeEach(function () {
     jest
       .spyOn(apiClient, 'type')

--- a/src/store/SubjectStore.spec.js
+++ b/src/store/SubjectStore.spec.js
@@ -49,7 +49,15 @@ describe('SubjectStore', function () {
 })
 
 describe('SubjectStore error', function () {
+  let subjectStore
+
+  const mockSubject = {
+    id: '1',
+    locations: [],
+    metadata: {}
+  }
   let error = { message: 'No subject found' }
+
   beforeEach(function () {
     jest
       .spyOn(apiClient, 'type')
@@ -82,6 +90,14 @@ describe('SubjectStore error', function () {
 })
 
 describe('SubjectStore empty return when fetching subjects', function () {
+  let subjectStore
+
+  const mockSubject = {
+    id: '1',
+    locations: [],
+    metadata: {}
+  }
+
   it('should resolve the call without error', async function () {
     jest
       .spyOn(apiClient, 'type')

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -13,103 +13,103 @@ import {
   headers
 } from './testUtils/transcriptionsStore'
 
-let rootStore
-let transcriptionsStore
+describe('TranscriptionsStore', function () {
+  let rootStore
+  let transcriptionsStore
 
-const patchToveSpy = jest.fn().mockResolvedValue({ ok: true, headers })
-const toggleModalSpy = jest.fn()
+  const patchToveSpy = jest.fn().mockResolvedValue({ ok: true, headers })
+  const toggleModalSpy = jest.fn()
 
-const getToveLockedResponse = () => Promise.resolve(
-  {
-    body: JSON.stringify(
-      {
-        data: TranscriptionFactory.build({
-          attributes: { locked_by: 'ANOTHER_USER' }
-        })
-      })
-  }
-)
-
-const extract = {
-  data: mockExtract,
-  userId: '123',
-  classificationAt: 1515450629.237
-}
-
-const extracts = {
-  workflow: {
-    extracts: [extract]
-  }
-}
-
-const mockReduction = {
-  clusters_text: [],
-  clusters_x: [],
-  clusters_y: [],
-  consensus_score: 0,
-  consensus_text: 'Text',
-  edited_consensus_text: '',
-  extract_index: [],
-  flagged: true,
-  gold_standard: [],
-  gutter_label: 0,
-  line_editor: '',
-  line_slope: 0,
-  low_consensus: false,
-  number_views: 0,
-  original_transcriber: '',
-  seen: false,
-  slope_label: 0,
-  user_ids: []
-}
-
-const mockReaggregation = {
-  frame0: [{}],
-  low_consensus_lines: 1,
-  parameters: {},
-  reducer: 'reducer',
-  transcribed_lines: 2
-}
-
-const user = {
-  id: '123',
-  display_name: 'A_User'
-}
-
-const postCaesarSpy = jest.fn().mockResolvedValue({ body: mockReaggregation })
-
-const multipleTranscriptionsStub = {
-  get: () => Promise.resolve(
+  const getToveLockedResponse = () => Promise.resolve(
     {
       body: JSON.stringify(
         {
-          data: [TranscriptionFactory.build(), TranscriptionFactory.build({ id: '2', attributes: { status: STATUS.APPROVED, subject_id: '2', text: new Map() }})],
-          meta: {
-            pagination: { last: 1, records: 2 },
-            approved_count: 1
-          }
+          data: TranscriptionFactory.build({
+            attributes: { locked_by: 'ANOTHER_USER' }
+          })
         })
     }
-  ),
-  patch: patchToveSpy
-}
+  )
 
-const aggregatorStub = {
-  post: postCaesarSpy
-}
-const failedAggregatorPost = {
-  post: jest.fn().mockResolvedValue({ ok: false })
-}
-const singleTranscriptionStub = {
-  get: getToveResponse,
-  patch: patchToveSpy
-}
+  const extract = {
+    data: mockExtract,
+    userId: '123',
+    classificationAt: 1515450629.237
+  }
 
-const lockedTranscriptionStub = {
-  get: getToveLockedResponse
-}
+  const extracts = {
+    workflow: {
+      extracts: [extract]
+    }
+  }
 
-describe('TranscriptionsStore', function () {
+  const mockReduction = {
+    clusters_text: [],
+    clusters_x: [],
+    clusters_y: [],
+    consensus_score: 0,
+    consensus_text: 'Text',
+    edited_consensus_text: '',
+    extract_index: [],
+    flagged: true,
+    gold_standard: [],
+    gutter_label: 0,
+    line_editor: '',
+    line_slope: 0,
+    low_consensus: false,
+    number_views: 0,
+    original_transcriber: '',
+    seen: false,
+    slope_label: 0,
+    user_ids: []
+  }
+
+  const mockReaggregation = {
+    frame0: [{}],
+    low_consensus_lines: 1,
+    parameters: {},
+    reducer: 'reducer',
+    transcribed_lines: 2
+  }
+
+  const user = {
+    id: '123',
+    display_name: 'A_User'
+  }
+
+  const postCaesarSpy = jest.fn().mockResolvedValue({ body: mockReaggregation })
+
+  const multipleTranscriptionsStub = {
+    get: () => Promise.resolve(
+      {
+        body: JSON.stringify(
+          {
+            data: [TranscriptionFactory.build(), TranscriptionFactory.build({ id: '2', attributes: { status: STATUS.APPROVED, subject_id: '2', text: new Map() }})],
+            meta: {
+              pagination: { last: 1, records: 2 },
+              approved_count: 1
+            }
+          })
+      }
+    ),
+    patch: patchToveSpy
+  }
+
+  const aggregatorStub = {
+    post: postCaesarSpy
+  }
+  const failedAggregatorPost = {
+    post: jest.fn().mockResolvedValue({ ok: false })
+  }
+  const singleTranscriptionStub = {
+    get: getToveResponse,
+    patch: patchToveSpy
+  }
+
+  const lockedTranscriptionStub = {
+    get: getToveLockedResponse
+  }
+
   describe('fetching multiple transcriptions', function () {
     describe('success state', function () {
       beforeEach(async function () {

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -1,7 +1,7 @@
 import ASYNC_STATES from 'helpers/asyncStates'
 import * as graphQl from 'graphql-request'
+import { when } from 'mobx'
 import apiClient from 'panoptes-client/lib/api-client.js';
-import { mockExtract } from 'helpers/parseTranscriptionData.spec'
 import mockJWT from 'helpers/mockJWT'
 import STATUS from 'helpers/status'
 import { AppStore } from './AppStore'
@@ -32,7 +32,17 @@ describe('TranscriptionsStore', function () {
   )
 
   const extract = {
-    data: mockExtract,
+    data: {
+    frame0: {
+      slope: [0],
+      text: [['My text for this line']],
+      points: {
+        x: [[200, 200]],
+        y: [[300, 300]]
+      }
+    },
+    time: new Date()
+  },
     userId: '123',
     classificationAt: 1515450629.237
   }
@@ -209,7 +219,8 @@ describe('TranscriptionsStore', function () {
           { writable: true, value: toggleModalSpy }
         )
         transcriptionsStore = rootStore.transcriptions
-        await transcriptionsStore.selectTranscription(1)
+        transcriptionsStore.selectTranscription(1)
+        await when(() => transcriptionsStore.parsedExtracts.length > 0)
       })
 
       afterEach(() => jest.clearAllMocks());

--- a/src/store/WorkflowsStore.spec.js
+++ b/src/store/WorkflowsStore.spec.js
@@ -3,44 +3,44 @@ import mockJWT from 'helpers/mockJWT'
 import { AppStore } from './AppStore'
 import WorkflowFactory from './factories/workflow'
 
-let workflowsStore
-let rootStore
-const workflowTwo = WorkflowFactory.build({ id: '2' })
-
-let toveStubArray = {
-  get: () => Promise.resolve(
-    {
-      body: JSON.stringify(
-        {
-          data: [WorkflowFactory.build(), workflowTwo],
-          meta: {
-            pagination: { last: 1 }
-          }
-        })
-    }
-  )
-}
-
-let toveStub = {
-  get: () => Promise.resolve(
-    {
-      body: JSON.stringify(
-        {
-          data: workflowTwo,
-          meta: {
-            pagination: { last: 1 }
-          }
-        })
-    }
-  )
-}
-
-const error = { message: 'Failed to Return' }
-let failedToveStub = {
-  get: () => Promise.reject(error)
-}
-
 describe('WorkflowsStore', function () {
+  let workflowsStore
+  let rootStore
+  const workflowTwo = WorkflowFactory.build({ id: '2' })
+
+  let toveStubArray = {
+    get: () => Promise.resolve(
+      {
+        body: JSON.stringify(
+          {
+            data: [WorkflowFactory.build(), workflowTwo],
+            meta: {
+              pagination: { last: 1 }
+            }
+          })
+      }
+    )
+  }
+
+  let toveStub = {
+    get: () => Promise.resolve(
+      {
+        body: JSON.stringify(
+          {
+            data: workflowTwo,
+            meta: {
+              pagination: { last: 1 }
+            }
+          })
+      }
+    )
+  }
+
+  const error = { message: 'Failed to Return' }
+  let failedToveStub = {
+    get: () => Promise.reject(error)
+  }
+
   describe('success state', function () {
     beforeEach(function () {
       rootStore = AppStore.create({


### PR DESCRIPTION
Test setup variables, like `wrapper`, are declared globally across all tests. This removes the global declarations and scopes test variables to the `describe` functions that use them.

I've also added a debug script so that you can run `yarn test:debug` to inspect failing tests in your favourite Node debugger.