### PR TITLE
Add HTTPS for development and tidy up legacy code

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,20 +1,8 @@
-const path = require('path')
-
-function webpackFinal(config, options) {
-  config.resolve.modules = [
-    ...(config.resolve.modules || []),
-    path.resolve(__dirname, "../src")
-  ];
-
-  return config
-}
-
 module.exports = {
   stories: ['../src/**/*.stories.js'],
   addons: [
     '@storybook/addon-actions',
     '@storybook/addon-links',
     '@storybook/preset-create-react-app'
-  ],
-  webpackFinal
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project uses [Yarn](https://yarnpkg.com/en/docs) or [Docker](https://docs.d
 - `yarn install` to install package dependencies  
 - `yarn test` to run all tests within the repo  
 - `yarn storybook` to open a [Storybook](https://storybook.js.org) viewer at `http://localhost:6006` to view components in isolation  
-- `yarn start` to open a staging version of the site at `http://localhost:3000` (may need to set up `local.zooniverse.org:3000` to login, [instructions](https://stackoverflow.com/c/zooniverse/questions/109))
+- `yarn start` to open a staging version of the site at `https://localhost:3000`. Use `https://local.zooniverse.org:3000` to log in via the Panoptes API ([instructions](https://stackoverflow.com/c/zooniverse/questions/109).)
 
 **Docker**
 - `docker-compose up` to run the development app at `http://localhost:3000` and start storybook at `http://localhost:6006`

--- a/package.json
+++ b/package.json
@@ -44,12 +44,11 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "~1.15.6",
     "nock": "^13.2.4",
-    "require-context.macro": "^1.2.2",
     "react-scripts": "3.4.4"
   },
   "homepage": "https://alice.zooniverse.org",
   "scripts": {
-    "start": "react-scripts start",
+    "start": "HTTPS=true react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --coverage --watchAll=false --silent",
     "test:debug": "react-scripts --inspect test --runInBand --no-cache",

--- a/src/components/SubjectViewer/components/SVGView/SVGView.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGView.js
@@ -15,9 +15,9 @@ const SVG = styled.svg`
 `
 
 const SVGView = React.forwardRef(function ({ disabled, height, image, url, transform, width}, ref) {
-  if (url.length === 0 || disabled || !ref) return null;
-
   const [isMoving, setMove] = React.useState(false)
+
+  if (url.length === 0 || disabled || !ref) return null;
 
   const boundingBox = ref.current && ref.current.getBoundingClientRect()
   const viewerWidth = (boundingBox && boundingBox.width) || 0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,7 +2432,7 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/webpack-env@^1.14.0", "@types/webpack-env@^1.15.0":
+"@types/webpack-env@^1.15.0":
   version "1.16.3"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.16.3.tgz#b776327a73e561b71e7881d0cd6d34a1424db86a"
   integrity sha512-9gtOPPkfyNoEqCQgx4qJKkuNm/x0R2hKR7fdl7zvTJyHnIisuE/LfvXOsYWL0o3qq6uiBnKZNNNzi3l0y/X+xw==
@@ -12442,13 +12442,6 @@ request@^2.87.0, request@^2.88.0, request@^2.88.2:
     tough-cookie "~2.5.0"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
-
-require-context.macro@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/require-context.macro/-/require-context.macro-1.2.2.tgz#84bc90f6b9c6dec3a840c84cfd6b2dd92884e34d"
-  integrity sha512-qibgUj+t0YeBAIsQSqgY3iwFrwQoAV7mmZmvdEpGwe1eAS7iunLpINsRYX/lyuHtJDeJdF7U92jXNzbuDeM2RA==
-  dependencies:
-    "@types/webpack-env" "^1.14.0"
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
- allow local development to use `https://local.zooniverse.org`.
- update the README for local development.
- Fix `useState` in `SVGView`. Hooks can't appear after conditional returns.
- Remove legacy Storybook config (from Storybook 3, I think.)