### PR TITLE
Show the username for locked pages

### DIFF
--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -112,6 +112,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     const lockedBy = resource.data.attributes.locked_by
     const lockedByDifferentUser = lockedBy && lockedBy !== getRoot(self).auth.user.login
     if (lockedByDifferentUser) {
+      self.current.lockedBy = lockedBy
       getRoot(self).modal.toggleModal(MODALS.LOCKED)
     }
   })

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -112,7 +112,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     const lockedBy = resource.data.attributes.locked_by
     const lockedByDifferentUser = lockedBy && lockedBy !== getRoot(self).auth.user.login
     if (lockedByDifferentUser) {
-      self.current.lockedBy = lockedBy
+      self.current.locked_by = lockedBy
       getRoot(self).modal.toggleModal(MODALS.LOCKED)
     }
   })

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -364,6 +364,7 @@ describe('TranscriptionsStore', function () {
         })
 
         it('should show when the transcription is locked', async function () {
+          await unlockedTranscriptionStore.selectTranscription(1)
           await unlockedTranscriptionStore.checkIfLocked()
           expect(toggleModalSpy).toHaveBeenCalled()
         })


### PR DESCRIPTION
Store the `lockedBy` username when a page is locked. Fixes a bug where the ‘locked’ modal opens but the username is empty, preventing you from seeing who has the page open for editing. See the screenshot in #329. 