### PR TITLE
Redirect to /projects if already logged in

### DIFF
--- a/src/store/AppStore.js
+++ b/src/store/AppStore.js
@@ -12,6 +12,7 @@ import { ProjectsStore } from './ProjectsStore'
 import { ModalStore } from './ModalStore'
 import { TranscriptionsStore } from './TranscriptionsStore'
 import { WorkflowsStore } from './WorkflowsStore'
+import history from '../history'
 
 const AppStore = types.model('AppStore', {
   aggregations: types.optional(AggregationsStore, () => AggregationsStore.create({})),
@@ -57,6 +58,9 @@ const AppStore = types.model('AppStore', {
     self.client.initialize()
     yield self.auth.checkCurrent()
     self.initialized = true;
+    if (self.auth.user) {
+      history.push('/projects')
+    }
   })
 
   return {


### PR DESCRIPTION
Works around a bug where the log-in form on the home page crashes with `'id' is read-only` if you log in while already logged in.